### PR TITLE
[feat] 웨이블존 리뷰 목록 조회 API 구현 

### DIFF
--- a/src/main/java/com/wayble/server/review/controller/ReviewController.java
+++ b/src/main/java/com/wayble/server/review/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.wayble.server.review.controller;
 
 import com.wayble.server.common.response.CommonResponse;
 import com.wayble.server.review.dto.ReviewRegisterDto;
+import com.wayble.server.review.dto.ReviewResponseDto;
 import com.wayble.server.review.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,6 +12,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,5 +40,18 @@ public class ReviewController {
     ) {
         reviewService.registerReview(waybleZoneId, dto, authorizationHeader);
         return CommonResponse.success("리뷰가 등록되었습니다.");
+    }
+
+    @GetMapping
+    @Operation(summary = "웨이블존 리뷰 목록 조회", description = "웨이블존에 대한 리뷰를 최신순 또는 평점순으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 웨이블존이 존재하지 않음")
+    })
+    public CommonResponse<List<ReviewResponseDto>> getReviews(
+            @PathVariable Long waybleZoneId,
+            @RequestParam(defaultValue = "latest") String sort
+    ) {
+        return CommonResponse.success(reviewService.getReviews(waybleZoneId, sort));
     }
 }

--- a/src/main/java/com/wayble/server/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/wayble/server/review/dto/ReviewResponseDto.java
@@ -1,4 +1,14 @@
 package com.wayble.server.review.dto;
 
-public record ReviewResponseDto() {
-}
+import java.time.LocalDate;
+import java.util.List;
+
+public record ReviewResponseDto(
+        Long reviewId,
+        String userNickname,
+        double rating,
+        String content,
+        LocalDate visitDate,
+        int likes,
+        List<String> images
+) {}

--- a/src/main/java/com/wayble/server/review/repository/ReviewRepository.java
+++ b/src/main/java/com/wayble/server/review/repository/ReviewRepository.java
@@ -3,5 +3,9 @@ package com.wayble.server.review.repository;
 import com.wayble.server.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findByWaybleZoneIdOrderByCreatedAtDesc(Long waybleZoneId); // 최신순
+    List<Review> findByWaybleZoneIdOrderByRatingDesc(Long waybleZoneId); // 평점순
 }

--- a/src/main/java/com/wayble/server/user/entity/UserPlace.java
+++ b/src/main/java/com/wayble/server/user/entity/UserPlace.java
@@ -1,0 +1,29 @@
+package com.wayble.server.user.entity;
+
+import com.wayble.server.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "user_place") // 유져가 저장한 장소
+public class UserPlace extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/com/wayble/server/user/entity/UserPlaceWaybleZoneMapping.java
+++ b/src/main/java/com/wayble/server/user/entity/UserPlaceWaybleZoneMapping.java
@@ -1,0 +1,29 @@
+package com.wayble.server.user.entity;
+
+import com.wayble.server.wayblezone.entity.WaybleZone;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "user_place_wayble_zone_mapping") // 유저 장소와 웨이블존 다대다 매핑
+public class UserPlaceWaybleZoneMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_place_id", nullable = false)
+    private UserPlace userPlace;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "wayble_zone_id", nullable = false)
+    private WaybleZone waybleZone;
+}

--- a/src/main/java/com/wayble/server/wayblezone/entity/WaybleZone.java
+++ b/src/main/java/com/wayble/server/wayblezone/entity/WaybleZone.java
@@ -3,6 +3,7 @@ package com.wayble.server.wayblezone.entity;
 import com.wayble.server.common.entity.Address;
 import com.wayble.server.common.entity.BaseEntity;
 import com.wayble.server.review.entity.Review;
+import com.wayble.server.user.entity.UserPlaceWaybleZoneMapping;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
@@ -18,23 +19,29 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE wayble_zone SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
-@Table(name = "wayble_zone")
+@Table(name = "wayble_zone") // 웨이블 존
 public class WaybleZone extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String zoneName;
+    private String zoneName; // 가게 이름
 
-    private String contactNumber;
+    private String contactNumber; // 가게 전화 번호
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private WaybleZoneType zoneType;
+    private WaybleZoneType zoneType; // 가게 타입 (음식점,카페,편의점)
 
     @Embedded
-    private Address address;
+    private Address address; // 주소
+
+    @Column(nullable = false)
+    private double rating = 0.0; // 누적 평균 평점
+
+    @Column(nullable = false)
+    private int reviewCount = 0; // 리뷰 수
 
     @OneToMany(mappedBy = "waybleZone", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WaybleZoneImage> waybleZoneImageList = new ArrayList<>();
@@ -42,19 +49,12 @@ public class WaybleZone extends BaseEntity {
     @OneToMany(mappedBy = "waybleZone", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();
 
-    /**
-     * TODO: 영업 시간 구현 필요
-     */
+    @OneToMany(mappedBy = "waybleZone", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WaybleZoneOperatingHour> operatingHours = new ArrayList<>();
 
-    /**
-     * TODO: 장애 시설 정보 구현 필요
-     */
+    @OneToOne(mappedBy = "waybleZone", cascade = CascadeType.ALL, orphanRemoval = true)
+    private WaybleZoneFacility facility;
 
-    /**
-     * TODO: Review 관련 엔티티 구현 필요
-     */
-
-    /**
-     * TODO: 내가 저장한 장소 관련 엔티티 구현 필요
-     */
+    @OneToMany(mappedBy = "waybleZone", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserPlaceWaybleZoneMapping> userPlaceMappings = new ArrayList<>();
 }

--- a/src/main/java/com/wayble/server/wayblezone/entity/WaybleZoneFacility.java
+++ b/src/main/java/com/wayble/server/wayblezone/entity/WaybleZoneFacility.java
@@ -1,0 +1,42 @@
+package com.wayble.server.wayblezone.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "wayble_zone_facility")
+public class WaybleZoneFacility {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 웨이블존 연관관계 (1:1로 가정 => 웨이블존당 시설 1세트)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "wayble_zone_id", nullable = false)
+    private WaybleZone waybleZone;
+
+    // 시설 정보 (있음/없음 여부)
+    @Column(nullable = false)
+    private boolean hasSlope; // 경사로
+
+    @Column(nullable = false)
+    private boolean hasNoDoorStep; // 문턱
+
+    @Column(nullable = false)
+    private boolean hasElevator; // 엘리베이터
+
+    @Column(nullable = false)
+    private boolean hasTableSeat; // 테이블석
+
+    @Column(nullable = false)
+    private boolean hasDisabledToilet; // 장애인 화장실
+
+    @Column(length = 20)
+    private String floorInfo; // 층수 정보 (ex: "1층", "B1", "2층")
+}

--- a/src/main/java/com/wayble/server/wayblezone/entity/WaybleZoneFacility.java
+++ b/src/main/java/com/wayble/server/wayblezone/entity/WaybleZoneFacility.java
@@ -1,5 +1,6 @@
 package com.wayble.server.wayblezone.entity;
 
+import com.wayble.server.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,8 +10,8 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "wayble_zone_facility")
-public class WaybleZoneFacility {
+@Table(name = "wayble_zone_facility") // 웨이블존 편의 시설 정보 
+public class WaybleZoneFacility extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/wayble/server/wayblezone/entity/WaybleZoneFacility.java
+++ b/src/main/java/com/wayble/server/wayblezone/entity/WaybleZoneFacility.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "wayble_zone_facility") // 웨이블존 편의 시설 정보 
+@Table(name = "wayble_zone_facility") // 웨이블존 편의 시설 정보
 public class WaybleZoneFacility extends BaseEntity {
 
     @Id

--- a/src/main/java/com/wayble/server/wayblezone/entity/WaybleZoneOperatingHour.java
+++ b/src/main/java/com/wayble/server/wayblezone/entity/WaybleZoneOperatingHour.java
@@ -1,0 +1,35 @@
+package com.wayble.server.wayblezone.entity;
+
+import com.wayble.server.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "wayble_zone_operating_hours") // 웨이블존 영업 정보
+public class WaybleZoneOperatingHour extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "wayble_zone_id", nullable = false)
+    private WaybleZone waybleZone;
+
+    @Column(name = "day_of_week", nullable = false)
+    private String dayOfWeek; // 요일 정보
+
+    @Column(name = "start_time", nullable = false)
+    private String startTime; // 영업 시작 시간
+
+    @Column(name = "close_time", nullable = false)
+    private String closeTime; // 영업 종료 시간
+}

--- a/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
+++ b/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum WaybleZoneErrorCase implements ErrorCase {
 
-    WAYBLE_ZONE_NOT_FOUND(400, 2001, "웨이블존을 찾을 수 없습니다.");
+    WAYBLE_ZONE_NOT_FOUND(404, 2001, "해당 웨이블존을 찾을 수 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#24 

## 📝 작업 내용
- 웨이블존 리뷰 목록 조회 API 구현 (GET /api/v1/wayble-zones/{waybleZoneId}/reviews?sort=latest|rating)
- 리뷰 정렬 기능
- 리뷰 응답 DTO (ReviewResponseDto) 구현 
- WaybleZone 엔티티에 리뷰 수(reviewCount)와 평균 평점(rating) 필드 추가
- WaybleZoneFacility 엔티티: 웨이블존의 편의 시설 정보 
- WaybleZoneOperatingHour 엔티티: 요일별 운영 시간 정보
- WaybleZoneErrorCase의 WAYBLE_ZONE_NOT_FOUND HTTP 상태 코드를 404로 수정

## 📸 스크린샷 (선택)
- 응답성공
![리뷰목록조회api성공](https://github.com/user-attachments/assets/cef506b3-4fdb-4cbe-b108-897ad6df3ed1)

- 응답실패
![화면 캡처 2025-07-10 033242](https://github.com/user-attachments/assets/0e6b19c4-194f-41d4-930f-f15cd2ed8d18)


## 💬 리뷰 요구사항(선택)
WaybleZoneFacility 엔티티를 WaybleZoneFacilityMapping으로 하여 매핑 테이블 방식으로 구현하려고 했지만,
WaybleZoneFacility 자체가 여러 boolean 필드(경사로, 문턱 없음, 엘리베이터 등) 기반의 구조이기 때문에
facility_id를 FK로 매핑해도 boolean 필드 기반 구조와 충돌 가능성이 있어 해당 방식을 채택하지 않았습니다.

=> 따라서 웨이블존 편의 시설 정보는 단일 엔티티로 Boolean 필드로 구성하였고, 포함한 필드(hasSlope, hasNoDoorStep, hasElevator, hasTableSeat, hasDisabledToilet)는 현재 피그마 UI를 기준으로 설계하였고, 만약 해당 정보가 바뀐다면 나중에 필드 수정이 필요할 것 같습니다. 