### PR TITLE
[feat] 웨이블존 목록 조회 API 구현 

### DIFF
--- a/src/main/java/com/wayble/server/common/entity/Address.java
+++ b/src/main/java/com/wayble/server/common/entity/Address.java
@@ -38,4 +38,14 @@ public class Address {
     /** 경도 */
     @Column(name = "longitude", columnDefinition = "DECIMAL(10,7)", nullable = false)
     private Double longitude;
+
+    public String toFullAddress() {
+        StringBuilder sb = new StringBuilder();
+        if (state != null) sb.append(state).append(" ");
+        if (city != null) sb.append(city).append(" ");
+        if (district != null) sb.append(district).append(" ");
+        if (streetAddress != null) sb.append(streetAddress).append(" ");
+        if (detailAddress != null) sb.append(detailAddress);
+        return sb.toString().trim();
+    }
 }

--- a/src/main/java/com/wayble/server/wayblezone/controller/WaybleZoneController.java
+++ b/src/main/java/com/wayble/server/wayblezone/controller/WaybleZoneController.java
@@ -1,29 +1,29 @@
 package com.wayble.server.wayblezone.controller;
 
 import com.wayble.server.common.response.CommonResponse;
+import com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto;
 import com.wayble.server.wayblezone.service.WaybleZoneService;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/wayble-zones")
+@RequestMapping("/api/v1/wayble-zones")
 public class WaybleZoneController {
 
     private final WaybleZoneService waybleZoneService;
 
-    // 참고용 컨트롤러(지우셔도 돼요)
-    @GetMapping("/hello")
-    public CommonResponse<String> hello() {
-        return CommonResponse.success("hello");
-    }
-
-    // 예외 사용 참고용 컨트롤러(지우셔도 돼요)
-    @GetMapping("/ex")
-    public CommonResponse<String> exception() {
-        waybleZoneService.makeException();
-        return CommonResponse.success("예외 발생!");
+    @GetMapping
+    public CommonResponse<List<WaybleZoneListResponseDto>> getWaybleZoneList(
+            @RequestParam @NotBlank(message = "city는 필수입니다.") String city,
+            @RequestParam @NotBlank(message = "category는 필수입니다.") String category
+    ) {
+        return CommonResponse.success(waybleZoneService.getWaybleZones(city, category));
     }
 }

--- a/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneListResponseDto.java
+++ b/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneListResponseDto.java
@@ -1,0 +1,27 @@
+package com.wayble.server.wayblezone.dto;
+
+import lombok.Builder;
+
+@Builder
+public record WaybleZoneListResponseDto(
+        Long waybleZoneId,
+        String name,
+        String category,
+        String address,
+        double rating,
+        int reviewCount,
+        String imageUrl,
+        String contactNumber,
+        FacilityDto facilities
+) {
+    @Builder
+    public record FacilityDto(
+            boolean hasSlope,
+            boolean hasNoDoorStep,
+            boolean hasElevator,
+            boolean hasTableSeat,
+            boolean hasDisabledToilet,
+            String floorInfo
+    ) {}
+}
+

--- a/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
+++ b/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
@@ -10,7 +10,7 @@ public enum WaybleZoneErrorCase implements ErrorCase {
 
     WAYBLE_ZONE_NOT_FOUND(404, 2001, "해당 웨이블존을 찾을 수 없습니다."),
     INVALID_CATEGORY(400, 2002, "유효하지 않은 category 파라미터입니다."),
-    WAYBLE_ZONE_FACILITY_NOT_FOUND(404, 2002, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다.");
+    WAYBLE_ZONE_FACILITY_NOT_FOUND(404, 2003, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
+++ b/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum WaybleZoneErrorCase implements ErrorCase {
 
-    WAYBLE_ZONE_NOT_FOUND(404, 2001, "해당 웨이블존을 찾을 수 없습니다.");
+    WAYBLE_ZONE_NOT_FOUND(404, 2001, "해당 웨이블존을 찾을 수 없습니다."),
+    INVALID_CATEGORY(400, 2002, "유효하지 않은 category 파라미터입니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
+++ b/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum WaybleZoneErrorCase implements ErrorCase {
 
     WAYBLE_ZONE_NOT_FOUND(404, 2001, "해당 웨이블존을 찾을 수 없습니다."),
-    INVALID_CATEGORY(400, 2002, "유효하지 않은 category 파라미터입니다.");
+    INVALID_CATEGORY(400, 2002, "유효하지 않은 category 파라미터입니다."),
+    WAYBLE_ZONE_FACILITY_NOT_FOUND(404, 2002, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/wayblezone/repository/WaybleZoneRepository.java
+++ b/src/main/java/com/wayble/server/wayblezone/repository/WaybleZoneRepository.java
@@ -3,5 +3,8 @@ package com.wayble.server.wayblezone.repository;
 import com.wayble.server.wayblezone.entity.WaybleZone;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface WaybleZoneRepository extends JpaRepository<WaybleZone, Long> {
+    List<WaybleZone> findByAddress_CityContainingAndZoneType(String city, com.wayble.server.wayblezone.entity.WaybleZoneType category);
 }

--- a/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
+++ b/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
@@ -1,11 +1,19 @@
 package com.wayble.server.wayblezone.service;
 
 import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto;
+import com.wayble.server.wayblezone.entity.WaybleZone;
+import com.wayble.server.wayblezone.entity.WaybleZoneFacility;
+import com.wayble.server.wayblezone.entity.WaybleZoneImage;
+import com.wayble.server.wayblezone.entity.WaybleZoneType;
 import com.wayble.server.wayblezone.exception.WaybleZoneErrorCase;
-import com.wayble.server.wayblezone.repository.WaybleZoneImageRepository;
 import com.wayble.server.wayblezone.repository.WaybleZoneRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto.*;
 
 @Service
 @RequiredArgsConstructor
@@ -13,9 +21,39 @@ public class WaybleZoneService {
 
     private final WaybleZoneRepository waybleZoneRepository;
 
-    private final WaybleZoneImageRepository imageRepository;
+    public List<WaybleZoneListResponseDto> getWaybleZones(String city, String category) {
+        WaybleZoneType zoneType;
 
-    public void makeException() {
-        throw new ApplicationException(WaybleZoneErrorCase.WAYBLE_ZONE_NOT_FOUND);
+        try {
+            zoneType = WaybleZoneType.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ApplicationException(WaybleZoneErrorCase.INVALID_CATEGORY);
+        }
+
+        List<WaybleZone> zones = waybleZoneRepository.findByAddress_CityContainingAndZoneType(city, zoneType);
+
+        return zones.stream().map(zone -> {
+            WaybleZoneFacility f = zone.getFacility();
+            WaybleZoneImage image = zone.getWaybleZoneImageList().stream().findFirst().orElse(null);
+
+            return WaybleZoneListResponseDto.builder()
+                    .waybleZoneId(zone.getId())
+                    .name(zone.getZoneName())
+                    .category(zone.getZoneType().toString())
+                    .address(zone.getAddress().toFullAddress())
+                    .rating(zone.getRating())
+                    .reviewCount(zone.getReviewCount())
+                    .imageUrl(image != null ? image.getImageUrl() : null)
+                    .contactNumber(zone.getContactNumber())
+                    .facilities(FacilityDto.builder()
+                            .hasSlope(f.isHasSlope())
+                            .hasNoDoorStep(f.isHasNoDoorStep())
+                            .hasElevator(f.isHasElevator())
+                            .hasTableSeat(f.isHasTableSeat())
+                            .hasDisabledToilet(f.isHasDisabledToilet())
+                            .floorInfo(f.getFloorInfo())
+                            .build()
+                    ).build();
+        }).toList();
     }
 }

--- a/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
+++ b/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
@@ -34,6 +34,10 @@ public class WaybleZoneService {
 
         return zones.stream().map(zone -> {
             WaybleZoneFacility f = zone.getFacility();
+            if (f == null) {
+                throw new ApplicationException(WaybleZoneErrorCase.WAYBLE_ZONE_FACILITY_NOT_FOUND);
+            }
+
             WaybleZoneImage image = zone.getWaybleZoneImageList().stream().findFirst().orElse(null);
 
             return WaybleZoneListResponseDto.builder()


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#30 
## 📝 작업 내용
- city, category 파라미터를 기반으로 웨이블존에 대한 목록을 조회하는 API 구현
- 웨이블존 목록 조회 컨트롤러 추가
- 웨이블존 목록 조회 관련 서비스 로직 추가 
- DTO 작성
- 예외 처리 (웨이블존 시설 조회에 관한 예외 처리 추가)

## 📸 스크린샷 (선택)
### 응답성공
<img width="1463" height="834" alt="웨이블존목록조회성공" src="https://github.com/user-attachments/assets/0569d33c-7c03-4f57-8787-b6c1e3d4ab72" />

### 응답실패
<img width="1455" height="602" alt="웨이블존목록조회실패" src="https://github.com/user-attachments/assets/9957954a-5f54-491b-9eed-b6073e7a9922" />

## 💬 리뷰 요구사항(선택)
웨이블존 장애 시설 정보 항목이 경사로 여부, 장애인 화장실 여부, 테이블석 여부, 층수, 입구턱 여부, 엘리베이터 여부로 결정되었기 때문에 해당 정보를 바탕으로 웨이블존 리뷰 목록 조회 API 명세서를 수정하였고, Spring에 해당 목록으로 반영하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 도시와 카테고리별로 Wayble Zone 목록을 조회할 수 있는 GET API가 추가되었습니다.
  * 각 Wayble Zone의 상세 정보(이름, 카테고리, 주소, 평점, 리뷰 수, 이미지, 연락처, 편의시설 등)를 포함한 응답이 제공됩니다.
  * 주소 정보를 하나의 문자열로 반환하는 기능이 추가되었습니다.

* **버그 수정**
  * 잘못된 카테고리 입력 시 적절한 오류 메시지가 반환됩니다.
  * 시설 정보가 없는 경우 오류가 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->