### PR TITLE
[feat] 웨이블존 상세 조회 API 구현 

### DIFF
--- a/src/main/java/com/wayble/server/common/dto/FacilityDto.java
+++ b/src/main/java/com/wayble/server/common/dto/FacilityDto.java
@@ -1,0 +1,13 @@
+package com.wayble.server.common.dto;
+
+import lombok.Builder;
+
+@Builder
+public record FacilityDto(
+        boolean hasSlope,
+        boolean hasNoDoorStep,
+        boolean hasElevator,
+        boolean hasTableSeat,
+        boolean hasDisabledToilet,
+        String floorInfo
+) {}

--- a/src/main/java/com/wayble/server/wayblezone/controller/WaybleZoneController.java
+++ b/src/main/java/com/wayble/server/wayblezone/controller/WaybleZoneController.java
@@ -1,6 +1,7 @@
 package com.wayble.server.wayblezone.controller;
 
 import com.wayble.server.common.response.CommonResponse;
+import com.wayble.server.wayblezone.dto.WaybleZoneDetailResponseDto;
 import com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto;
 import com.wayble.server.wayblezone.service.WaybleZoneService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,11 +10,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -42,5 +41,17 @@ public class WaybleZoneController {
             @RequestParam @NotBlank(message = "category는 필수입니다.") String category
     ) {
         return CommonResponse.success(waybleZoneService.getWaybleZones(city, category));
+    }
+
+    @GetMapping("/{waybleZoneId}")
+    @Operation(summary = "웨이블존 상세 조회", description = "웨이블존의 상세 정보를 조회합니다. (운영시간 포함)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상세 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "웨이블존이 존재하지 않음")
+    })
+    public CommonResponse<WaybleZoneDetailResponseDto> getWaybleZoneDetail(
+            @PathVariable @NotNull Long waybleZoneId
+    ) {
+        return CommonResponse.success(waybleZoneService.getWaybleZoneDetail(waybleZoneId));
     }
 }

--- a/src/main/java/com/wayble/server/wayblezone/controller/WaybleZoneController.java
+++ b/src/main/java/com/wayble/server/wayblezone/controller/WaybleZoneController.java
@@ -3,6 +3,11 @@ package com.wayble.server.wayblezone.controller;
 import com.wayble.server.common.response.CommonResponse;
 import com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto;
 import com.wayble.server.wayblezone.service.WaybleZoneService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +25,18 @@ public class WaybleZoneController {
     private final WaybleZoneService waybleZoneService;
 
     @GetMapping
+    @Operation(
+            summary = "웨이블존 목록 조회",
+            description = "city, category 파라미터를 기반으로 웨이블존 리스트를 조회합니다. " +
+                    "각 웨이블존에 대해 이름, 주소, 평균 평점, 리뷰 수, 대표 이미지, 편의시설 정보를 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "웨이블존 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 category 파라미터",
+                    content = @Content(schema = @Schema(implementation = com.wayble.server.common.response.CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 웨이블존에 대한 시설 정보가 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = com.wayble.server.common.response.CommonResponse.class)))
+    })
     public CommonResponse<List<WaybleZoneListResponseDto>> getWaybleZoneList(
             @RequestParam @NotBlank(message = "city는 필수입니다.") String city,
             @RequestParam @NotBlank(message = "category는 필수입니다.") String category

--- a/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneDetailResponseDto.java
+++ b/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneDetailResponseDto.java
@@ -1,0 +1,37 @@
+package com.wayble.server.wayblezone.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record WaybleZoneDetailResponseDto(
+        Long waybleZoneId,
+        String name,
+        String category,
+        String address,
+        double rating,
+        int reviewCount,
+        String contactNumber,
+        String imageUrl,
+        FacilityDto facilities,
+        Map<String, BusinessHourDto> businessHours,
+        List<String> photos
+) {
+    @Builder
+    public record FacilityDto(
+            boolean hasSlope,
+            boolean hasNoDoorStep,
+            boolean hasElevator,
+            boolean hasTableSeat,
+            boolean hasDisabledToilet,
+            String floorInfo
+    ) {}
+
+    @Builder
+    public record BusinessHourDto(
+            String open,
+            String close
+    ) {}
+}

--- a/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneDetailResponseDto.java
+++ b/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.wayble.server.wayblezone.dto;
 
+import com.wayble.server.common.dto.FacilityDto;
 import lombok.Builder;
 
 import java.util.List;
@@ -19,16 +20,6 @@ public record WaybleZoneDetailResponseDto(
         Map<String, BusinessHourDto> businessHours,
         List<String> photos
 ) {
-    @Builder
-    public record FacilityDto(
-            boolean hasSlope,
-            boolean hasNoDoorStep,
-            boolean hasElevator,
-            boolean hasTableSeat,
-            boolean hasDisabledToilet,
-            String floorInfo
-    ) {}
-
     @Builder
     public record BusinessHourDto(
             String open,

--- a/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneListResponseDto.java
+++ b/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneListResponseDto.java
@@ -1,5 +1,6 @@
 package com.wayble.server.wayblezone.dto;
 
+import com.wayble.server.common.dto.FacilityDto;
 import lombok.Builder;
 
 @Builder
@@ -13,15 +14,5 @@ public record WaybleZoneListResponseDto(
         String imageUrl,
         String contactNumber,
         FacilityDto facilities
-) {
-    @Builder
-    public record FacilityDto(
-            boolean hasSlope,
-            boolean hasNoDoorStep,
-            boolean hasElevator,
-            boolean hasTableSeat,
-            boolean hasDisabledToilet,
-            String floorInfo
-    ) {}
-}
+) {}
 

--- a/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
+++ b/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
@@ -10,7 +10,8 @@ public enum WaybleZoneErrorCase implements ErrorCase {
 
     WAYBLE_ZONE_NOT_FOUND(404, 2001, "해당 웨이블존을 찾을 수 없습니다."),
     INVALID_CATEGORY(400, 2002, "유효하지 않은 category 파라미터입니다."),
-    WAYBLE_ZONE_FACILITY_NOT_FOUND(404, 2003, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다.");
+    WAYBLE_ZONE_FACILITY_NOT_FOUND(404, 2003, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다."),
+    FACILITY_NOT_FOUND(404, 2002, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
+++ b/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
@@ -11,7 +11,7 @@ public enum WaybleZoneErrorCase implements ErrorCase {
     WAYBLE_ZONE_NOT_FOUND(404, 2001, "해당 웨이블존을 찾을 수 없습니다."),
     INVALID_CATEGORY(400, 2002, "유효하지 않은 category 파라미터입니다."),
     WAYBLE_ZONE_FACILITY_NOT_FOUND(404, 2003, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다."),
-    FACILITY_NOT_FOUND(404, 2002, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다.");
+    FACILITY_NOT_FOUND(404, 2004, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
+++ b/src/main/java/com/wayble/server/wayblezone/exception/WaybleZoneErrorCase.java
@@ -10,8 +10,7 @@ public enum WaybleZoneErrorCase implements ErrorCase {
 
     WAYBLE_ZONE_NOT_FOUND(404, 2001, "해당 웨이블존을 찾을 수 없습니다."),
     INVALID_CATEGORY(400, 2002, "유효하지 않은 category 파라미터입니다."),
-    WAYBLE_ZONE_FACILITY_NOT_FOUND(404, 2003, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다."),
-    FACILITY_NOT_FOUND(404, 2004, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다.");
+    WAYBLE_ZONE_FACILITY_NOT_FOUND(404, 2003, "해당 웨이블존에 대한 시설 정보가 존재하지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
+++ b/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
@@ -1,19 +1,19 @@
 package com.wayble.server.wayblezone.service;
 
+import com.wayble.server.common.dto.FacilityDto;
 import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.wayblezone.dto.WaybleZoneDetailResponseDto;
 import com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto;
-import com.wayble.server.wayblezone.entity.WaybleZone;
-import com.wayble.server.wayblezone.entity.WaybleZoneFacility;
-import com.wayble.server.wayblezone.entity.WaybleZoneImage;
-import com.wayble.server.wayblezone.entity.WaybleZoneType;
+import com.wayble.server.wayblezone.entity.*;
 import com.wayble.server.wayblezone.exception.WaybleZoneErrorCase;
 import com.wayble.server.wayblezone.repository.WaybleZoneRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
 import java.util.List;
-
-import static com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto.*;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -59,5 +59,49 @@ public class WaybleZoneService {
                             .build()
                     ).build();
         }).toList();
+    }
+
+    public WaybleZoneDetailResponseDto getWaybleZoneDetail(Long waybleZoneId) {
+        WaybleZone zone = waybleZoneRepository.findById(waybleZoneId)
+                .orElseThrow(() -> new ApplicationException(WaybleZoneErrorCase.WAYBLE_ZONE_NOT_FOUND));
+
+        WaybleZoneFacility f = zone.getFacility();
+        if (f == null) throw new ApplicationException(WaybleZoneErrorCase.FACILITY_NOT_FOUND);
+
+        List<WaybleZoneImage> images = zone.getWaybleZoneImageList();
+        String imageUrl = images.stream().findFirst().map(WaybleZoneImage::getImageUrl).orElse(null);
+        List<String> photoUrls = images.stream().map(WaybleZoneImage::getImageUrl).toList();
+
+        Map<String, WaybleZoneDetailResponseDto.BusinessHourDto> businessHours = new LinkedHashMap<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        for (WaybleZoneOperatingHour hour : zone.getOperatingHours()) {
+            String dayKey = hour.getDayOfWeek().toString().toLowerCase();
+            businessHours.put(dayKey, WaybleZoneDetailResponseDto.BusinessHourDto.builder()
+                    .open(hour.getStartTime().format(formatter))
+                    .close(hour.getCloseTime().format(formatter))
+                    .build());
+        }
+
+        return WaybleZoneDetailResponseDto.builder()
+                .waybleZoneId(zone.getId())
+                .name(zone.getZoneName())
+                .category(zone.getZoneType().toString())
+                .address(zone.getAddress().toFullAddress())
+                .rating(zone.getRating())
+                .reviewCount(zone.getReviewCount())
+                .contactNumber(zone.getContactNumber())
+                .imageUrl(imageUrl)
+                .photos(photoUrls)
+                .facilities(FacilityDto.builder()
+                        .hasSlope(f.isHasSlope())
+                        .hasNoDoorStep(f.isHasNoDoorStep())
+                        .hasElevator(f.isHasElevator())
+                        .hasTableSeat(f.isHasTableSeat())
+                        .hasDisabledToilet(f.isHasDisabledToilet())
+                        .floorInfo(f.getFloorInfo())
+                        .build())
+                .businessHours(businessHours)
+                .build();
     }
 }

--- a/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
+++ b/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
@@ -66,7 +66,7 @@ public class WaybleZoneService {
                 .orElseThrow(() -> new ApplicationException(WaybleZoneErrorCase.WAYBLE_ZONE_NOT_FOUND));
 
         WaybleZoneFacility f = zone.getFacility();
-        if (f == null) throw new ApplicationException(WaybleZoneErrorCase.FACILITY_NOT_FOUND);
+        if (f == null) throw new ApplicationException(WaybleZoneErrorCase.WAYBLE_ZONE_FACILITY_NOT_FOUND);
 
         List<WaybleZoneImage> images = zone.getWaybleZoneImageList();
         String imageUrl = images.stream().findFirst().map(WaybleZoneImage::getImageUrl).orElse(null);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#30 

## 📝 작업 내용

- 웨이블존 상세 조회 API (GET /api/v1/wayble-zones/{waybleZoneId}) 구현

- 웨이블존 상세 정보, 편의시설, 운영시간, 이미지 목록 포함

- 운영시간은 요일별로 분류 후, DTO에 open/close 시간 포함

- FacilityDto가 웨이블존 목록 조회, 상세 조회 두 부분에서 중복으로 사용하기 때문에 공통 사용을 위해 common -> dto로 추가

- WaybleZoneService에서 시설 및 이미지가 존재하지 않는다면 null-safe 로직 처리 

## 📸 스크린샷 (선택)
### 응답성공
<img width="1481" height="900" alt="웨이블존상세조회성공" src="https://github.com/user-attachments/assets/f6c56d85-3f01-4ece-9457-71d04be5b3f0" />

### 응답실패
<img width="1472" height="609" alt="웨이블존상세조회실패" src="https://github.com/user-attachments/assets/1158d5fb-d555-4ecc-9525-b84314cb3c11" />

## 💬 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 특정 웨이블존의 상세 정보를 조회할 수 있는 엔드포인트가 추가되었습니다. 상세 정보에는 운영 시간, 시설 정보, 사진 등이 포함됩니다.

* **버그 수정**
  * 웨이블존 목록 응답에서 시설 정보 타입이 일관되게 개선되었습니다.

* **문서화**
  * 웨이블존 관련 API 엔드포인트에 대한 Swagger 문서가 추가되어, 응답 및 파라미터 정보가 명확하게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->