### PR TITLE
[feat] 유저 장소 저장 API 구현 

### DIFF
--- a/src/main/java/com/wayble/server/review/controller/ReviewController.java
+++ b/src/main/java/com/wayble/server/review/controller/ReviewController.java
@@ -38,7 +38,9 @@ public class ReviewController {
     public CommonResponse<String> registerReview(
             @PathVariable Long waybleZoneId,
             @RequestBody @Valid ReviewRegisterDto dto,
-            @RequestHeader(value = "Authorization", required = false) String authorizationHeader // 테스트를 위해 임시로 토큰 없이도 접근하도록 설정
+
+            // TODO: 로그인 구현 후 Authorization 헤더 필수로 변경 필요
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader
     ) {
         reviewService.registerReview(waybleZoneId, dto, authorizationHeader);
         return CommonResponse.success("리뷰가 등록되었습니다.");

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -1,11 +1,14 @@
 package com.wayble.server.user.controller;
 
+import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.common.response.CommonResponse;
 import com.wayble.server.user.dto.UserPlaceRequestDto;
+import com.wayble.server.user.exception.UserErrorCase;
 import com.wayble.server.user.service.UserPlaceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,11 +28,16 @@ public class UserPlaceController {
     })
     public CommonResponse<String> saveUserPlace(
             @PathVariable Long userId,
-            @RequestBody UserPlaceRequestDto request,
+            @RequestBody @Valid UserPlaceRequestDto request,
 
-            // 테스트를 위해 임시 허용 (로그인 구현되면 삭제)
+            // TODO: 로그인 구현 후 Authorization 헤더 필수로 변경 필요
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader
     ) {
+        // Path variable과 request body의 userId 일치 여부 확인
+        if (!userId.equals(request.userId())) {
+            throw new ApplicationException(UserErrorCase.INVALID_USER_ID);
+        }
+
         userPlaceService.saveUserPlace(request);
         return CommonResponse.success("장소가 저장되었습니다.");
     }

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -1,0 +1,36 @@
+package com.wayble.server.user.controller;
+
+import com.wayble.server.common.response.CommonResponse;
+import com.wayble.server.user.dto.UserPlaceRequestDto;
+import com.wayble.server.user.service.UserPlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/users/{userId}/places")
+@RequiredArgsConstructor
+public class UserPlaceController {
+
+    private final UserPlaceService userPlaceService;
+
+    @PostMapping
+    @Operation(summary = "유저 장소 저장", description = "유저가 웨이블존을 장소로 저장합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "장소 저장 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 저장한 장소입니다."),
+            @ApiResponse(responseCode = "404", description = "해당 유저 또는 웨이블존이 존재하지 않음")
+    })
+    public CommonResponse<String> saveUserPlace(
+            @PathVariable Long userId,
+            @RequestBody UserPlaceRequestDto request,
+
+            // 테스트를 위해 임시 허용 (로그인 구현되면 삭제)
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader
+    ) {
+        userPlaceService.saveUserPlace(request);
+        return CommonResponse.success("장소가 저장되었습니다.");
+    }
+}

--- a/src/main/java/com/wayble/server/user/dto/UserPlaceRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserPlaceRequestDto.java
@@ -2,7 +2,7 @@ package com.wayble.server.user.dto;
 
 import jakarta.validation.constraints.NotNull;
 
-public record UserPlaceSaveRequestDto(
+public record UserPlaceRequestDto(
         @NotNull Long userId,
         @NotNull Long waybleZoneId,
         @NotNull String title

--- a/src/main/java/com/wayble/server/user/dto/UserPlaceSaveRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserPlaceSaveRequestDto.java
@@ -1,0 +1,9 @@
+package com.wayble.server.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserPlaceSaveRequestDto(
+        @NotNull Long userId,
+        @NotNull Long waybleZoneId,
+        @NotNull String title
+) {}

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -58,5 +58,6 @@ public class User extends BaseEntity {
 
     // TODO 프로필 이미지 관련 작업 필요
 
-    // TODO 내가 저장한 장소 관련 작업 필요
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserPlace> userPlaces = new ArrayList<>();
 }

--- a/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
@@ -8,9 +8,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserErrorCase implements ErrorCase {
 
-    USER_NOT_FOUND(400, 1001, "사용자를 찾을 수 없습니다."),
+    USER_NOT_FOUND(404, 1001, "사용자를 찾을 수 없습니다."),
     WAYBLE_ZONE_NOT_FOUND(404, 1002, "해당 웨이블존을 찾을 수 없습니다."),
-    PLACE_ALREADY_SAVED(400, 1003, "이미 저장한 장소입니다.");
+    PLACE_ALREADY_SAVED(400, 1003, "이미 저장한 장소입니다."),
+    INVALID_USER_ID(400, 1004, "요청 경로의 유저 ID와 바디의 유저 ID가 일치하지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserErrorCase implements ErrorCase {
 
-    USER_NOT_FOUND(400, 1001, "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(400, 1001, "사용자를 찾을 수 없습니다."),
+    WAYBLE_ZONE_NOT_FOUND(404, 1002, "해당 웨이블존을 찾을 수 없습니다."),
+    PLACE_ALREADY_SAVED(400, 1003, "이미 저장한 장소입니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/user/repository/UserPlaceRepository.java
+++ b/src/main/java/com/wayble/server/user/repository/UserPlaceRepository.java
@@ -1,0 +1,10 @@
+package com.wayble.server.user.repository;
+
+import com.wayble.server.user.entity.UserPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserPlaceRepository extends JpaRepository<UserPlace, Long> {
+    Optional<UserPlace> findByUser_IdAndTitle(Long userId, String title);
+}

--- a/src/main/java/com/wayble/server/user/repository/UserPlaceWaybleZoneMappingRepository.java
+++ b/src/main/java/com/wayble/server/user/repository/UserPlaceWaybleZoneMappingRepository.java
@@ -1,0 +1,8 @@
+package com.wayble.server.user.repository;
+
+import com.wayble.server.user.entity.UserPlaceWaybleZoneMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPlaceWaybleZoneMappingRepository extends JpaRepository<UserPlaceWaybleZoneMapping, Long> {
+    boolean existsByUserPlace_User_IdAndWaybleZone_Id(Long userId, Long zoneId);
+}

--- a/src/main/java/com/wayble/server/user/service/UserPlaceService.java
+++ b/src/main/java/com/wayble/server/user/service/UserPlaceService.java
@@ -12,6 +12,7 @@ import com.wayble.server.user.repository.UserPlaceWaybleZoneMappingRepository;
 import com.wayble.server.user.repository.UserRepository;
 import com.wayble.server.wayblezone.entity.WaybleZone;
 import com.wayble.server.wayblezone.repository.WaybleZoneRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +25,7 @@ public class UserPlaceService {
     private final UserPlaceRepository userPlaceRepository;
     private final UserPlaceWaybleZoneMappingRepository mappingRepository;
 
+    @Transactional
     public void saveUserPlace(UserPlaceRequestDto request) {
         // 유저 존재 확인
         User user = userRepository.findById(request.userId())

--- a/src/main/java/com/wayble/server/user/service/UserPlaceService.java
+++ b/src/main/java/com/wayble/server/user/service/UserPlaceService.java
@@ -1,0 +1,57 @@
+package com.wayble.server.user.service;
+
+
+import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.user.dto.UserPlaceRequestDto;
+import com.wayble.server.user.entity.User;
+import com.wayble.server.user.entity.UserPlace;
+import com.wayble.server.user.entity.UserPlaceWaybleZoneMapping;
+import com.wayble.server.user.exception.UserErrorCase;
+import com.wayble.server.user.repository.UserPlaceRepository;
+import com.wayble.server.user.repository.UserPlaceWaybleZoneMappingRepository;
+import com.wayble.server.user.repository.UserRepository;
+import com.wayble.server.wayblezone.entity.WaybleZone;
+import com.wayble.server.wayblezone.repository.WaybleZoneRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserPlaceService {
+
+    private final UserRepository userRepository;
+    private final WaybleZoneRepository waybleZoneRepository;
+    private final UserPlaceRepository userPlaceRepository;
+    private final UserPlaceWaybleZoneMappingRepository mappingRepository;
+
+    public void saveUserPlace(UserPlaceRequestDto request) {
+        // 유저 존재 확인
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+
+        // 웨이블존 존재 확인
+        WaybleZone waybleZone = waybleZoneRepository.findById(request.waybleZoneId())
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.WAYBLE_ZONE_NOT_FOUND));
+
+        // 중복 저장 확인
+        boolean alreadySaved = mappingRepository.existsByUserPlace_User_IdAndWaybleZone_Id(request.userId(), request.waybleZoneId());
+        if (alreadySaved) {
+            throw new ApplicationException(UserErrorCase.PLACE_ALREADY_SAVED);
+        }
+
+        // 저장
+        UserPlace userPlace = userPlaceRepository.save(
+                UserPlace.builder()
+                        .title(request.title())
+                        .user(user)
+                        .build()
+        );
+
+        mappingRepository.save(
+                UserPlaceWaybleZoneMapping.builder()
+                        .userPlace(userPlace)
+                        .waybleZone(waybleZone)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#34 

## 📝 작업 내용

- 유저가 특정 웨이블존을 개인 장소로 저장할 수 있는 기능 구현 => /api/v1/users/{userId}/places
- 중복 저장 방지 로직 추가 → 이미 저장된 경우 400 Bad Request 반환
- 존재하지 않는 유저 or 웨이블존: 404 , 이미 저장된 장소: 400
## 📸 스크린샷 (선택)
### 응답 성공
<img width="1461" height="663" alt="유저장소저장성공" src="https://github.com/user-attachments/assets/1fa64616-36c2-4bab-9988-fddd38970dcf" />

### 응답 실패
<img width="1461" height="677" alt="유저장소저장실패" src="https://github.com/user-attachments/assets/2a056e32-e11a-4caf-a3f7-e2d1d32a7dc7" />

## 💬 리뷰 요구사항 (선택)
- 현재 로그인 구현 안되어있기때문에 Swagger 테스트를 위해 Authorization 헤더는 필수 아님으로 설정하였고, 이후 로그인 인증 붙일 때 @RequestHeader 수정 필요



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 웨이블존에 장소를 저장할 수 있는 API가 추가되었습니다.
  * 중복 저장 및 존재하지 않는 사용자/웨이블존에 대한 오류 처리가 개선되었습니다.
  * 저장된 장소 목록 관리 기능이 향상되었습니다.

* **버그 수정**
  * 장소 저장 시 중복 저장이나 잘못된 정보 입력에 대한 오류 메시지가 명확하게 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->