### PR TITLE
[feat] 내가 저정한 장소 목록 조회 API 구현 

### DIFF
--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -38,6 +38,9 @@ public class UserPlaceController {
             @RequestHeader(value = "Authorization") String authorizationHeader
     ) {
         String token = authorizationHeader.replace("Bearer ", "");
+        if (!jwtProvider.validateToken(token)) {
+            throw new ApplicationException(UserErrorCase.FORBIDDEN);
+        }
         Long tokenUserId = jwtProvider.getUserId(token);
 
         // Path variable과 request body의 userId 일치 여부 확인
@@ -63,7 +66,9 @@ public class UserPlaceController {
             @RequestHeader("Authorization") String authorizationHeader
     ) {
         String token = authorizationHeader.replace("Bearer ", "");
-
+        if (!jwtProvider.validateToken(token)) {
+            throw new ApplicationException(UserErrorCase.FORBIDDEN);
+        }
         Long tokenUserId = jwtProvider.getUserId(token);
 
         if (!userId.equals(tokenUserId)) {

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -1,5 +1,6 @@
 package com.wayble.server.user.controller;
 
+import com.wayble.server.common.config.security.jwt.JwtTokenProvider;
 import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.common.response.CommonResponse;
 import com.wayble.server.user.dto.UserPlaceListResponseDto;
@@ -21,6 +22,8 @@ import java.util.List;
 public class UserPlaceController {
 
     private final UserPlaceService userPlaceService;
+    private final JwtTokenProvider jwtProvider;
+
 
     @PostMapping
     @Operation(summary = "유저 장소 저장", description = "유저가 웨이블존을 장소로 저장합니다.")
@@ -32,12 +35,13 @@ public class UserPlaceController {
     public CommonResponse<String> saveUserPlace(
             @PathVariable Long userId,
             @RequestBody @Valid UserPlaceRequestDto request,
-
-            // TODO: 로그인 구현 후 Authorization 헤더 필수로 변경 필요
-            @RequestHeader(value = "Authorization", required = false) String authorizationHeader
+            @RequestHeader(value = "Authorization") String authorizationHeader
     ) {
+        String token = authorizationHeader.replace("Bearer ", "");
+        Long tokenUserId = jwtProvider.getUserId(token);
+
         // Path variable과 request body의 userId 일치 여부 확인
-        if (!userId.equals(request.userId())) {
+        if (!userId.equals(request.userId()) || !userId.equals(tokenUserId)) {
             throw new ApplicationException(UserErrorCase.INVALID_USER_ID);
         }
 
@@ -52,12 +56,20 @@ public class UserPlaceController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "장소 목록 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없음")
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없음"),
+            @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
     public CommonResponse<List<UserPlaceListResponseDto>> getUserPlaces(
             @PathVariable Long userId,
             @RequestHeader("Authorization") String authorizationHeader
     ) {
+        String token = authorizationHeader.replace("Bearer ", "");
+
+        Long tokenUserId = jwtProvider.getUserId(token);
+
+        if (!userId.equals(tokenUserId)) {
+            return CommonResponse.error(403, "권한이 없습니다.");
+        }
 
         List<UserPlaceListResponseDto> places = userPlaceService.getUserPlaces(userId);
         return CommonResponse.success(places);

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -44,11 +44,6 @@ public class UserPlaceController {
         if (!userId.equals(request.userId()) || !userId.equals(tokenUserId)) {
             throw new ApplicationException(UserErrorCase.FORBIDDEN);
         }
-
-        if (!userId.equals(request.userId())) {
-            throw new ApplicationException(UserErrorCase.FORBIDDEN);
-        }
-
         userPlaceService.saveUserPlace(request);
         return CommonResponse.success("장소가 저장되었습니다.");
     }

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -42,7 +42,11 @@ public class UserPlaceController {
 
         // Path variable과 request body의 userId 일치 여부 확인
         if (!userId.equals(request.userId()) || !userId.equals(tokenUserId)) {
-            throw new ApplicationException(UserErrorCase.INVALID_USER_ID);
+            throw new ApplicationException(UserErrorCase.FORBIDDEN);
+        }
+
+        if (!userId.equals(request.userId())) {
+            throw new ApplicationException(UserErrorCase.FORBIDDEN);
         }
 
         userPlaceService.saveUserPlace(request);
@@ -68,7 +72,7 @@ public class UserPlaceController {
         Long tokenUserId = jwtProvider.getUserId(token);
 
         if (!userId.equals(tokenUserId)) {
-            return CommonResponse.error(403, "권한이 없습니다.");
+            throw new ApplicationException(UserErrorCase.FORBIDDEN);
         }
 
         List<UserPlaceListResponseDto> places = userPlaceService.getUserPlaces(userId);

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -2,6 +2,7 @@ package com.wayble.server.user.controller;
 
 import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.common.response.CommonResponse;
+import com.wayble.server.user.dto.UserPlaceListResponseDto;
 import com.wayble.server.user.dto.UserPlaceRequestDto;
 import com.wayble.server.user.exception.UserErrorCase;
 import com.wayble.server.user.service.UserPlaceService;
@@ -11,6 +12,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/users/{userId}/places")
@@ -40,5 +43,23 @@ public class UserPlaceController {
 
         userPlaceService.saveUserPlace(request);
         return CommonResponse.success("장소가 저장되었습니다.");
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "내가 저장한 장소 목록 조회",
+            description = "유저가 저장한 모든 장소 및 해당 웨이블존 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "장소 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없음")
+    })
+    public CommonResponse<List<UserPlaceListResponseDto>> getUserPlaces(
+            @PathVariable Long userId,
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+
+        List<UserPlaceListResponseDto> places = userPlaceService.getUserPlaces(userId);
+        return CommonResponse.success(places);
     }
 }

--- a/src/main/java/com/wayble/server/user/dto/UserPlaceListResponseDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserPlaceListResponseDto.java
@@ -1,0 +1,22 @@
+package com.wayble.server.user.dto;
+
+import lombok.Builder;
+
+
+
+@Builder
+public record UserPlaceListResponseDto(
+        Long place_id,
+        String title,
+        WaybleZoneDto wayble_zone
+) {
+    @Builder
+    public record WaybleZoneDto(
+            Long wayble_zone_id,
+            String name,
+            String category,
+            double rating,
+            String address,
+            String image_url
+    ) {}
+}

--- a/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
@@ -13,7 +13,8 @@ public enum UserErrorCase implements ErrorCase {
     PLACE_ALREADY_SAVED(400, 1003, "이미 저장한 장소입니다."),
     INVALID_USER_ID(400, 1004, "요청 경로의 유저 ID와 바디의 유저 ID가 일치하지 않습니다."),
     USER_ALREADY_EXISTS(400, 1005, "이미 존재하는 회원입니다."),
-    INVALID_CREDENTIALS(400, 1006, "아이디 혹은 비밀번호가 잘못되었습니다.");
+    INVALID_CREDENTIALS(400, 1006, "아이디 혹은 비밀번호가 잘못되었습니다."),
+    FORBIDDEN(403, 1007, "권한이 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/user/repository/UserPlaceWaybleZoneMappingRepository.java
+++ b/src/main/java/com/wayble/server/user/repository/UserPlaceWaybleZoneMappingRepository.java
@@ -3,6 +3,9 @@ package com.wayble.server.user.repository;
 import com.wayble.server.user.entity.UserPlaceWaybleZoneMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserPlaceWaybleZoneMappingRepository extends JpaRepository<UserPlaceWaybleZoneMapping, Long> {
     boolean existsByUserPlace_User_IdAndWaybleZone_Id(Long userId, Long zoneId);
+    List<UserPlaceWaybleZoneMapping> findAllByUserPlace_User_Id(Long userId);
 }

--- a/src/main/java/com/wayble/server/user/service/UserPlaceService.java
+++ b/src/main/java/com/wayble/server/user/service/UserPlaceService.java
@@ -2,6 +2,7 @@ package com.wayble.server.user.service;
 
 
 import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.user.dto.UserPlaceListResponseDto;
 import com.wayble.server.user.dto.UserPlaceRequestDto;
 import com.wayble.server.user.entity.User;
 import com.wayble.server.user.entity.UserPlace;
@@ -15,6 +16,8 @@ import com.wayble.server.wayblezone.repository.WaybleZoneRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -55,5 +58,37 @@ public class UserPlaceService {
                         .waybleZone(waybleZone)
                         .build()
         );
+    }
+
+    public List<UserPlaceListResponseDto> getUserPlaces(Long userId) {
+        // 유저 존재 여부 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+
+        List<UserPlaceWaybleZoneMapping> mappings = mappingRepository.findAllByUserPlace_User_Id(userId);
+
+        return mappings.stream().map(mapping -> {
+            UserPlace userPlace = mapping.getUserPlace();
+            WaybleZone waybleZone = mapping.getWaybleZone();
+
+            // 웨이블존 대표 이미지 가져오기
+            String imageUrl = waybleZone.getWaybleZoneImageList().stream()
+                    .findFirst().map(img -> img.getImageUrl()).orElse(null);
+
+            return UserPlaceListResponseDto.builder()
+                    .place_id(userPlace.getId())
+                    .title(userPlace.getTitle())
+                    .wayble_zone(
+                            UserPlaceListResponseDto.WaybleZoneDto.builder()
+                                    .wayble_zone_id(waybleZone.getId())
+                                    .name(waybleZone.getZoneName())
+                                    .category(waybleZone.getZoneType().toString())
+                                    .rating(waybleZone.getRating())
+                                    .address(waybleZone.getAddress().toFullAddress())
+                                    .image_url(imageUrl)
+                                    .build()
+                    )
+                    .build();
+        }).toList();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#54 

## 📝 작업 내용
- 유저가 저장한 장소 목록을 조회하는 API (GET /api/v1/users/{userId}/places) 를 구현했습니다.
- 각 장소 별로 저장한 제목 및 연결된 웨이블존의 목록들을 포함하였습니다.
- JWT 토큰 검증 로직을 추가하여 다른 사용자가 조회 및 전송을 못하도록 403 에러 로직도 추가하였습니다.

## 🖼️ 스크린샷 (선택)
### 장소 목록 조회 성공
<img width="1475" height="943" alt="내가저장한장소목록조회성공(1)" src="https://github.com/user-attachments/assets/b859fb38-fbe2-445e-afbd-b9a01dc0d27a" />

### 조회 실패 (권한이 없는 사용자)
<img width="1464" height="941" alt="유저장소저장목록조회실패(1)" src="https://github.com/user-attachments/assets/4cbcaf33-0b90-46ba-9880-50d31a6642ab" />

## 💬 리뷰 요구사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 저장한 장소 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
* **버그 수정**
  * 사용자 장소 저장 및 조회 시 JWT 인증이 필수로 적용되어, 권한이 없는 접근이 차단됩니다.
* **기타**
  * 권한이 없을 때 반환되는 에러 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->