### PR TITLE
[feat] 카카오 소셜 로그인 구현 

### DIFF
--- a/src/main/java/com/wayble/server/user/controller/KakaoLoginController.java
+++ b/src/main/java/com/wayble/server/user/controller/KakaoLoginController.java
@@ -1,0 +1,37 @@
+package com.wayble.server.user.controller;
+
+import com.wayble.server.common.response.CommonResponse;
+import com.wayble.server.user.dto.KakaoLoginRequestDto;
+import com.wayble.server.user.dto.KakaoLoginResponseDto;
+import com.wayble.server.user.service.auth.KakaoLoginService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/login")
+@RequiredArgsConstructor
+public class KakaoLoginController {
+
+    private final KakaoLoginService kakaoLoginService;
+
+    @PostMapping("/kakao")
+    @Operation(summary = "카카오 소셜 로그인", description = "카카오 AccessToken으로 소셜 로그인을 수행합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "카카오 인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public CommonResponse<KakaoLoginResponseDto> kakaoLogin(
+            @RequestBody @Valid KakaoLoginRequestDto request
+    ) {
+        KakaoLoginResponseDto response = kakaoLoginService.kakaoLogin(request);
+        return CommonResponse.success(response);
+    }
+}

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -1,6 +1,5 @@
 package com.wayble.server.user.controller;
 
-import com.wayble.server.common.config.security.jwt.JwtTokenProvider;
 import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.common.response.CommonResponse;
 import com.wayble.server.user.dto.UserPlaceListResponseDto;
@@ -35,8 +34,7 @@ public class UserPlaceController {
     })
     public CommonResponse<String> saveUserPlace(
             @PathVariable Long userId,
-            @RequestBody @Valid UserPlaceRequestDto request,
-            @RequestHeader(value = "Authorization") String authorizationHeader
+            @RequestBody @Valid UserPlaceRequestDto request
     ) {
         Long tokenUserId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (!userId.equals(tokenUserId)) {
@@ -58,8 +56,7 @@ public class UserPlaceController {
             @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
     public CommonResponse<List<UserPlaceListResponseDto>> getUserPlaces(
-            @PathVariable Long userId,
-            @RequestHeader("Authorization") String authorizationHeader
+            @PathVariable Long userId
     ) {
         Long tokenUserId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (!userId.equals(tokenUserId)) {

--- a/src/main/java/com/wayble/server/user/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/wayble/server/user/dto/KakaoUserInfoDto.java
@@ -1,22 +1,26 @@
 package com.wayble.server.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoUserInfoDto {
     private Long id;
     private KakaoAccount kakao_account;
 
     @Getter
     @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KakaoAccount {
         private String email;
         private Profile profile;
 
         @Getter
         @Setter
+        @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Profile {
             private String nickname;
             private String profile_image_url;

--- a/src/main/java/com/wayble/server/user/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/wayble/server/user/dto/KakaoUserInfoDto.java
@@ -1,0 +1,25 @@
+package com.wayble.server.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoUserInfoDto {
+    private Long id;
+    private KakaoAccount kakao_account;
+
+    @Getter
+    @Setter
+    public static class KakaoAccount {
+        private String email;
+        private Profile profile;
+
+        @Getter
+        @Setter
+        public static class Profile {
+            private String nickname;
+            private String profile_image_url;
+        }
+    }
+}

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -89,4 +89,8 @@ public class User extends BaseEntity {
                 .userType(userType)
                 .build();
     }
+
+    public void setProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -44,7 +44,7 @@ public class User extends BaseEntity {
     private LocalDate birthDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Gender gender;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
@@ -14,7 +14,8 @@ public enum UserErrorCase implements ErrorCase {
     INVALID_USER_ID(400, 1004, "요청 경로의 유저 ID와 바디의 유저 ID가 일치하지 않습니다."),
     USER_ALREADY_EXISTS(400, 1005, "이미 존재하는 회원입니다."),
     INVALID_CREDENTIALS(400, 1006, "아이디 혹은 비밀번호가 잘못되었습니다."),
-    FORBIDDEN(403, 1007, "권한이 없습니다.");
+    FORBIDDEN(403, 1007, "권한이 없습니다."),
+    KAKAO_AUTH_FAILED(401, 1008, "카카오 인증에 실패하였습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/user/service/auth/KakaoLoginService.java
+++ b/src/main/java/com/wayble/server/user/service/auth/KakaoLoginService.java
@@ -90,8 +90,11 @@ public class KakaoLoginService {
                     .bodyToMono(String.class)
                     .block();
 
+            System.out.println("카카오 응답: " + response);
+
             return objectMapper.readValue(response, KakaoUserInfoDto.class);
         } catch (Exception e) {
+            e.printStackTrace();
             throw new ApplicationException(UserErrorCase.KAKAO_AUTH_FAILED);
         }
     }

--- a/src/main/java/com/wayble/server/user/service/auth/KakaoLoginService.java
+++ b/src/main/java/com/wayble/server/user/service/auth/KakaoLoginService.java
@@ -1,0 +1,98 @@
+package com.wayble.server.user.service.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wayble.server.common.config.security.jwt.JwtTokenProvider;
+import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.user.dto.KakaoLoginRequestDto;
+import com.wayble.server.user.dto.KakaoLoginResponseDto;
+import com.wayble.server.user.dto.KakaoUserInfoDto;
+import com.wayble.server.user.entity.LoginType;
+import com.wayble.server.user.entity.User;
+import com.wayble.server.user.entity.UserType;
+import com.wayble.server.user.exception.UserErrorCase;
+import com.wayble.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtProvider;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String KAKAO_USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    public KakaoLoginResponseDto kakaoLogin(KakaoLoginRequestDto request) {
+        // 카카오에서 사용자 정보 조회
+        KakaoUserInfoDto kakaoUserInfo = fetchKakaoUserInfo(request.accessToken());
+
+        String email = kakaoUserInfo.getKakao_account().getEmail();
+        String nickname = kakaoUserInfo.getKakao_account().getProfile().getNickname();
+        String profileImage = kakaoUserInfo.getKakao_account().getProfile().getProfile_image_url();
+        Long kakaoId = kakaoUserInfo.getId();
+
+        // 유저 검색 (카카오ID + KAKAO 타입)
+        Optional<User> userOpt = userRepository.findByEmailAndLoginType(email, LoginType.KAKAO);
+        boolean isNewUser = false;
+        User user;
+
+        if (userOpt.isEmpty()) {
+            // 신규 가입자라면 회원가입 처리
+            user = User.createUser(
+                    nickname,
+                    email,       // username
+                    email,
+                    "",          // password
+                    null,        // birthDate
+                    null,        // gender
+                    LoginType.KAKAO,
+                    UserType.GENERAL
+            );
+            // 프로필 이미지 추가
+            user.setProfileImageUrl(profileImage);
+
+            user = userRepository.save(user);
+            isNewUser = true;
+        } else {
+            user = userOpt.get();
+        }
+
+        // JWT 토큰 발급
+        String accessToken = jwtProvider.generateToken(user.getId(), user.getUserType().name());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+
+
+        return KakaoLoginResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isNewUser(isNewUser)
+                .user(KakaoLoginResponseDto.UserDto.builder()
+                        .id(user.getId())
+                        .nickname(user.getNickname())
+                        .email(user.getEmail())
+                        .build())
+                .build();
+    }
+
+    // 카카오 사용자 정보 요청
+    private KakaoUserInfoDto fetchKakaoUserInfo(String kakaoAccessToken) {
+        try {
+            String response = WebClient.create()
+                    .get()
+                    .uri(KAKAO_USERINFO_URL)
+                    .header("Authorization", "Bearer " + kakaoAccessToken)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            return objectMapper.readValue(response, KakaoUserInfoDto.class);
+        } catch (Exception e) {
+            throw new ApplicationException(UserErrorCase.KAKAO_AUTH_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#58 

## 📝 작업 내용
**카카오 소셜 로그인 API 구현**
- /api/v1/users/login/kakao 엔드포인트 추가하였습니다. (POST)
- 카카오측에서 AccessToken을 받아 사용자 정보를 조회하고 JWT 토큰 발급받는 형식으로 구현했습니다.
- 닉네임/이메일/프로필이미지 등 3개의 회원 정보 저장을 반영하였습니다.
- 카카오 소셜 로그인에 필요한 관련 DTO 설계를 진행했습니다.
- 유저 엔티티의 gender 필드를 null 허용 했습니다. (카카오 소셜 로그인에서 동의항목에 성별을 받아오지 않아서 null로 들어가기때문에 해당 이유로 null 허용 했습니다. -> 동의항목에서 성별 받아오려면 앱 등록이 필요해서 현재는 null 허용으로 진행)

## 🖼️ 스크린샷 (선택)
### client_id,redirect_uri  설정 후 들어와지는 화면
예시 url: https://kauth.kakao.com/oauth/authorize?client_id=REST_API_KEY&redirect_uri=http://localhost:8080/api/v1/users/login/kakao&response_type=code&scope=profile_nickname,account_email
<img width="652" height="908" alt="카카오소셜로그인화면" src="https://github.com/user-attachments/assets/88df6dac-b6c8-422a-84da-8c75e86bba6d" />

### 카카오 디벨로퍼 -> 동의항목
<img width="1242" height="760" alt="카카오동의항목" src="https://github.com/user-attachments/assets/e0093a14-ad98-4467-8e94-8a821843cf47" />

### 카카오에서 지급한 토큰 발급 성공 (postman)
<img width="1542" height="944" alt="토큰발급성공(1)" src="https://github.com/user-attachments/assets/98de5d5c-292a-4250-8d6a-7b56b3ccee0f" />

### 지급받은 토큰으로 직접 swagger에서 테스트 진행 후 로그인 성공 (swagger)
<img width="1472" height="943" alt="스웨거테스트성공(1)" src="https://github.com/user-attachments/assets/6f24aed7-1fef-4572-9101-2c40f444bde3" />


## 💬 리뷰 요구사항 (선택)
> ### 현재 리팩토링 진행중입니다. 모든 작업이 끝난 후에 머지하겠습니다. (테스트 완료)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 소셜 로그인을 지원하는 API 엔드포인트가 추가되었습니다.
  * 카카오 로그인 시 신규 가입 여부 및 사용자 정보를 반환합니다.

* **버그 수정**
  * 카카오 사용자 정보 응답에서 알 수 없는 JSON 필드를 무시하도록 개선되었습니다.

* **기타**
  * 사용자 성별 정보가 선택적으로 입력될 수 있도록 변경되었습니다.
  * 카카오 인증 실패 시의 에러 메시지가 추가되었습니다.
  * 사용자 장소 저장 및 조회 API에서 Authorization 헤더 파라미터가 제거되어 인증 처리가 내부 보안 컨텍스트를 통해 이루어집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->