### PR TITLE
[feat] 웨이블존 추천, 검색 응답 필드에 장애 시설 정보 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
+	implementation 'com.amazonaws:aws-java-sdk-core:1.12.698'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.698'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 

--- a/src/main/java/com/wayble/server/common/entity/BaseEntity.java
+++ b/src/main/java/com/wayble/server/common/entity/BaseEntity.java
@@ -23,4 +23,8 @@ public class BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public void restore() {
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/com/wayble/server/explore/controller/WaybleZoneSearchController.java
+++ b/src/main/java/com/wayble/server/explore/controller/WaybleZoneSearchController.java
@@ -21,7 +21,7 @@ public class WaybleZoneSearchController {
 
     private final WaybleZoneSearchService waybleZoneSearchService;
 
-    @GetMapping("")
+    @GetMapping("/maps")
     public CommonResponse<SearchSliceDto<WaybleZoneSearchResponseDto>> findByCondition(
             @Valid @ModelAttribute WaybleZoneSearchConditionDto conditionDto,
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/com/wayble/server/explore/dto/FacilityResponseDto.java
+++ b/src/main/java/com/wayble/server/explore/dto/FacilityResponseDto.java
@@ -1,0 +1,29 @@
+package com.wayble.server.explore.dto;
+
+import com.wayble.server.explore.entity.EsWaybleZoneFacility;
+import lombok.Builder;
+
+@Builder
+public record FacilityResponseDto(
+        Boolean hasSlope,
+        Boolean hasNoDoorStep,
+        Boolean hasElevator,
+        Boolean hasTableSeat,
+        Boolean hasDisabledToilet,
+        String floorInfo
+) {
+    public static FacilityResponseDto from(EsWaybleZoneFacility facility) {
+        if (facility == null) {
+            return null;
+        }
+        
+        return FacilityResponseDto.builder()
+                .hasSlope(facility.isHasSlope())
+                .hasNoDoorStep(facility.isHasNoDoorStep())
+                .hasElevator(facility.isHasElevator())
+                .hasTableSeat(facility.isHasTableSeat())
+                .hasDisabledToilet(facility.isHasDisabledToilet())
+                .floorInfo(facility.getFloorInfo())
+                .build();
+    }
+}

--- a/src/main/java/com/wayble/server/explore/dto/recommend/WaybleZoneRecommendResponseDto.java
+++ b/src/main/java/com/wayble/server/explore/dto/recommend/WaybleZoneRecommendResponseDto.java
@@ -1,5 +1,6 @@
 package com.wayble.server.explore.dto.recommend;
 
+import com.wayble.server.explore.dto.FacilityResponseDto;
 import com.wayble.server.explore.entity.WaybleZoneDocument;
 import com.wayble.server.wayblezone.entity.WaybleZoneType;
 import lombok.Builder;
@@ -23,6 +24,8 @@ public record WaybleZoneRecommendResponseDto(
 
         Long reviewCount,
 
+        FacilityResponseDto facility,
+
         Double distanceScore,
 
         Double similarityScore,
@@ -42,6 +45,7 @@ public record WaybleZoneRecommendResponseDto(
                 .reviewCount(waybleZoneDocument.getReviewCount())
                 .latitude(waybleZoneDocument.getAddress().getLocation().getLat())
                 .longitude(waybleZoneDocument.getAddress().getLocation().getLon())
+                .facility(FacilityResponseDto.from(waybleZoneDocument.getFacility()))
                 .distanceScore(0.0)
                 .similarityScore(0.0)
                 .recencyScore(0.0)

--- a/src/main/java/com/wayble/server/explore/dto/search/WaybleZoneDocumentRegisterDto.java
+++ b/src/main/java/com/wayble/server/explore/dto/search/WaybleZoneDocumentRegisterDto.java
@@ -1,6 +1,7 @@
 package com.wayble.server.explore.dto.search;
 
 import com.wayble.server.common.entity.Address;
+import com.wayble.server.wayblezone.entity.WaybleZoneFacility;
 import com.wayble.server.wayblezone.entity.WaybleZoneType;
 import lombok.Builder;
 
@@ -11,6 +12,7 @@ public record WaybleZoneDocumentRegisterDto(
         WaybleZoneType waybleZoneType,
         String thumbnailImageUrl,
         Address address,
+        WaybleZoneFacility facility,
         Double averageRating,
         Long reviewCount
 ) {

--- a/src/main/java/com/wayble/server/explore/dto/search/WaybleZoneSearchResponseDto.java
+++ b/src/main/java/com/wayble/server/explore/dto/search/WaybleZoneSearchResponseDto.java
@@ -1,5 +1,6 @@
 package com.wayble.server.explore.dto.search;
 
+import com.wayble.server.explore.dto.FacilityResponseDto;
 import com.wayble.server.explore.entity.WaybleZoneDocument;
 import com.wayble.server.wayblezone.entity.WaybleZoneType;
 import lombok.AccessLevel;
@@ -24,7 +25,9 @@ public record WaybleZoneSearchResponseDto(
 
         Double averageRating,
 
-        Long reviewCount
+        Long reviewCount,
+
+        FacilityResponseDto facility
 ) {
     public static WaybleZoneSearchResponseDto from(WaybleZoneDocument waybleZoneDocument, Double distance) {
         return WaybleZoneSearchResponseDto.builder()
@@ -37,6 +40,7 @@ public record WaybleZoneSearchResponseDto(
                 .distance(distance)
                 .latitude(waybleZoneDocument.getAddress().getLocation().getLat())
                 .longitude(waybleZoneDocument.getAddress().getLocation().getLon())
+                .facility(FacilityResponseDto.from(waybleZoneDocument.getFacility()))
                 .build();
     }
 }

--- a/src/main/java/com/wayble/server/explore/entity/EsWaybleZoneFacility.java
+++ b/src/main/java/com/wayble/server/explore/entity/EsWaybleZoneFacility.java
@@ -1,0 +1,34 @@
+package com.wayble.server.explore.entity;
+
+import com.wayble.server.wayblezone.entity.WaybleZoneFacility;
+import lombok.*;
+
+@ToString
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EsWaybleZoneFacility {
+    
+    private boolean hasSlope;
+    private boolean hasNoDoorStep;
+    private boolean hasElevator;
+    private boolean hasTableSeat;
+    private boolean hasDisabledToilet;
+    private String floorInfo;
+    
+    public static EsWaybleZoneFacility from(WaybleZoneFacility facility) {
+        if (facility == null) {
+            return null;
+        }
+        
+        return EsWaybleZoneFacility.builder()
+                .hasSlope(facility.isHasSlope())
+                .hasNoDoorStep(facility.isHasNoDoorStep())
+                .hasElevator(facility.isHasElevator())
+                .hasTableSeat(facility.isHasTableSeat())
+                .hasDisabledToilet(facility.isHasDisabledToilet())
+                .floorInfo(facility.getFloorInfo())
+                .build();
+    }
+}

--- a/src/main/java/com/wayble/server/explore/entity/WaybleZoneDocument.java
+++ b/src/main/java/com/wayble/server/explore/entity/WaybleZoneDocument.java
@@ -33,6 +33,9 @@ public class WaybleZoneDocument {
     @Field(type = FieldType.Object)
     private EsAddress address;
 
+    @Field(type = FieldType.Object)
+    private EsWaybleZoneFacility facility;
+
     private double averageRating;
 
     private long reviewCount;
@@ -44,6 +47,7 @@ public class WaybleZoneDocument {
                 .zoneType(waybleZone.getZoneType())
                 .thumbnailImageUrl("thumbnail image url")   // TODO: 이미지 경로 추가
                 .address(EsAddress.from(waybleZone.getAddress()))
+                .facility(EsWaybleZoneFacility.from(waybleZone.getFacility()))
                 .averageRating(0.0)
                 .reviewCount(0L)
                 .build();
@@ -56,6 +60,7 @@ public class WaybleZoneDocument {
                 .zoneType(dto.waybleZoneType())
                 .thumbnailImageUrl(dto.thumbnailImageUrl())
                 .address(EsAddress.from(dto.address()))
+                .facility(EsWaybleZoneFacility.from(dto.facility()))
                 .averageRating(dto.averageRating() != null ? dto.averageRating() : 0.0)
                 .reviewCount(dto.reviewCount() != null ? dto.reviewCount() : 0L)
                 .build();

--- a/src/main/java/com/wayble/server/explore/entity/WaybleZoneDocument.java
+++ b/src/main/java/com/wayble/server/explore/entity/WaybleZoneDocument.java
@@ -45,7 +45,7 @@ public class WaybleZoneDocument {
                 .zoneId(waybleZone.getId())
                 .zoneName(waybleZone.getZoneName())
                 .zoneType(waybleZone.getZoneType())
-                .thumbnailImageUrl("thumbnail image url")   // TODO: 이미지 경로 추가
+                .thumbnailImageUrl(waybleZone.getMainImageUrl() != null ? waybleZone.getMainImageUrl() : null)   // TODO: 이미지 경로 추가
                 .address(EsAddress.from(waybleZone.getAddress()))
                 .facility(EsWaybleZoneFacility.from(waybleZone.getFacility()))
                 .averageRating(0.0)

--- a/src/main/java/com/wayble/server/explore/repository/recommend/WaybleZoneQueryRecommendRepository.java
+++ b/src/main/java/com/wayble/server/explore/repository/recommend/WaybleZoneQueryRecommendRepository.java
@@ -139,6 +139,7 @@ public class WaybleZoneQueryRecommendRepository {
                             .longitude(zone.getAddress().getLocation().getLon())
                             .averageRating(zone.getAverageRating())
                             .reviewCount(zone.getReviewCount())
+                            .facility(com.wayble.server.explore.dto.FacilityResponseDto.from(zone.getFacility()))
                             .distanceScore(distanceScore)
                             .similarityScore(similarityScore)
                             .recencyScore(recencyScore)

--- a/src/main/java/com/wayble/server/explore/service/WaybleZoneRecommendService.java
+++ b/src/main/java/com/wayble/server/explore/service/WaybleZoneRecommendService.java
@@ -57,7 +57,7 @@ public class WaybleZoneRecommendService {
         return recommendResponseDtoList;
     }
 
-    public Optional<WaybleZoneRecommendResponseDto> getTodayRecommendZone(Long userId) {
+    private Optional<WaybleZoneRecommendResponseDto> getTodayRecommendZone(Long userId) {
         LocalDate today = LocalDate.now();
         Optional<RecommendLogDocument> recommendLogDocument = recommendLogDocumentRepository.findByUserIdAndRecommendationDate(userId, today);
 
@@ -72,7 +72,7 @@ public class WaybleZoneRecommendService {
         }
     }
 
-    public void saveRecommendLog(Long userId, Long zoneId) {
+    private void saveRecommendLog(Long userId, Long zoneId) {
         String logId = UUID.randomUUID().toString();
         LocalDate dateNow = LocalDate.now();
 
@@ -88,7 +88,7 @@ public class WaybleZoneRecommendService {
         recommendLogDocumentRepository.save(recommendLogDocument);
     }
 
-    public void updateRecommendLog(Long userId, Long zoneId) {
+    private void updateRecommendLog(Long userId, Long zoneId) {
         RecommendLogDocument recommendLogDocument = recommendLogDocumentRepository.findByUserIdAndZoneId(userId, zoneId)
                 .orElseThrow(() -> new ApplicationException(RecommendErrorCase.RECOMMEND_LOG_NOT_EXIST));
 

--- a/src/main/java/com/wayble/server/user/repository/UserRepository.java
+++ b/src/main/java/com/wayble/server/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.wayble.server.user.repository;
 import com.wayble.server.user.entity.LoginType;
 import com.wayble.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmailAndLoginType(String email, LoginType loginType);
     Optional<User> findByEmailAndLoginType(String email, LoginType loginType);
+    @Query(value = "SELECT * FROM user WHERE email = :email AND login_type = :#{#loginType.name()} AND deleted_at IS NOT NULL", nativeQuery = true)
+    Optional<User> findDeletedUserByEmailAndLoginType(String email, @Param("loginType") LoginType loginType);
 }

--- a/src/main/java/com/wayble/server/user/repository/UserRepository.java
+++ b/src/main/java/com/wayble/server/user/repository/UserRepository.java
@@ -12,6 +12,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmailAndLoginType(String email, LoginType loginType);
     Optional<User> findByEmailAndLoginType(String email, LoginType loginType);
-    @Query(value = "SELECT * FROM user WHERE email = :email AND login_type = :#{#loginType.name()} AND deleted_at IS NOT NULL", nativeQuery = true)
-    Optional<User> findDeletedUserByEmailAndLoginType(String email, @Param("loginType") LoginType loginType);
 }

--- a/src/main/java/com/wayble/server/wayblezone/controller/WaybleZoneController.java
+++ b/src/main/java/com/wayble/server/wayblezone/controller/WaybleZoneController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -57,7 +58,8 @@ public class WaybleZoneController {
     ) {
 
         // TODO: JWT에서 userId 추출해서 상세 조회 기록 남기기
-        // waybleZoneVisitLogService.saveVisitLog(null, waybleZoneId);
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        waybleZoneVisitLogService.saveVisitLog(userId, waybleZoneId);
         return CommonResponse.success(waybleZoneService.getWaybleZoneDetail(waybleZoneId));
     }
 }

--- a/src/main/resources/elasticsearch/settings/wayble_zone_mappings.json
+++ b/src/main/resources/elasticsearch/settings/wayble_zone_mappings.json
@@ -7,6 +7,29 @@
     },
     "address.location": {
       "type": "geo_point"
+    },
+    "facility": {
+      "type": "object",
+      "properties": {
+        "hasSlope": {
+          "type": "boolean"
+        },
+        "hasNoDoorStep": {
+          "type": "boolean"
+        },
+        "hasElevator": {
+          "type": "boolean"
+        },
+        "hasTableSeat": {
+          "type": "boolean"
+        },
+        "hasDisabledToilet": {
+          "type": "boolean"
+        },
+        "floorInfo": {
+          "type": "keyword"
+        }
+      }
     }
   }
 }

--- a/src/test/java/com/wayble/server/explore/WaybleZoneRecommendApiIntegrationTest.java
+++ b/src/test/java/com/wayble/server/explore/WaybleZoneRecommendApiIntegrationTest.java
@@ -26,11 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -101,9 +98,10 @@ public class WaybleZoneRecommendApiIntegrationTest {
     @BeforeAll
     public void setup() {
         User testUser = User.createUser(
-                "testUser", "testUsername", "test@email.com", "password",
+                "testUser", "testUsername", UUID.randomUUID() + "@email", "password",
                 generateRandomBirthDate(), Gender.MALE, LoginType.KAKAO, UserType.DISABLED
         );
+
         userRepository.save(testUser);
         userId = testUser.getId();
         token = jwtTokenProvider.generateToken(userId, "ROLE_USER");
@@ -153,7 +151,7 @@ public class WaybleZoneRecommendApiIntegrationTest {
             User user = User.createUser(
                     "user" + i,
                     "username" + i,
-                    "user" + i + "@email",
+                    UUID.randomUUID() + "@email",
                     "password" + i,
                     generateRandomBirthDate(),
                     Gender.values()[i % 2],
@@ -184,7 +182,6 @@ public class WaybleZoneRecommendApiIntegrationTest {
         waybleZoneVisitLogDocumentRepository.deleteAll();
         recommendLogDocumentRepository.deleteAll();
         userRepository.deleteAll();
-        //SecurityContextHolder.getContext().setAuthentication(null);
     }
 
     @Test

--- a/src/test/java/com/wayble/server/explore/WaybleZoneRecommendApiIntegrationTest.java
+++ b/src/test/java/com/wayble/server/explore/WaybleZoneRecommendApiIntegrationTest.java
@@ -188,24 +188,17 @@ public class WaybleZoneRecommendApiIntegrationTest {
     @DisplayName("데이터 저장 테스트")
     public void checkDataExists() {
         List<WaybleZoneDocument> waybleZoneDocumentList = waybleZoneDocumentRepository.findAll();
-        System.out.println("=== 웨이블존 목록 ===");
-
         assertThat(waybleZoneDocumentList.size()).isGreaterThan(0);
+        System.out.println("Total documents: " + waybleZoneDocumentList.size());
         for (WaybleZoneDocument doc : waybleZoneDocumentList) {
             assertThat(doc.getZoneId()).isNotNull();
             assertThat(doc.getZoneName()).isNotNull();
             assertThat(doc.getAddress().getLocation()).isNotNull();
-            System.out.println("존 정보: " + doc.toString());
-            System.out.println("주소: " + doc.getAddress().toString());
         }
 
         List<WaybleZoneVisitLogDocument> waybleZoneVisitLogList = waybleZoneVisitLogDocumentRepository.findAll();
-        System.out.println("=== 웨이블존 방문 목록 ===");
-
         assertThat(waybleZoneVisitLogList.size()).isGreaterThan(0);
-        for (WaybleZoneVisitLogDocument doc : waybleZoneVisitLogList) {
-            System.out.println("방문 정보" + doc.toString());
-        }
+        System.out.println("visit log size: " + waybleZoneVisitLogList.size());
     }
 
     @Test
@@ -240,12 +233,6 @@ public class WaybleZoneRecommendApiIntegrationTest {
         assertThat(recommendLogDocument.get().getUserId()).isEqualTo(userId);
         assertThat(recommendLogDocument.get().getZoneId()).isEqualTo(zoneId);
         assertThat(recommendLogDocument.get().getRecommendationDate()).isEqualTo(LocalDate.now());
-        System.out.println("===recommend log===");
-        System.out.println("id = " + recommendLogDocument.get().getId());
-        System.out.println("userId = " +recommendLogDocument.get().getUserId());
-        System.out.println("zoneId = " +recommendLogDocument.get().getZoneId());
-        System.out.println("recommendationDate = " +recommendLogDocument.get().getRecommendationDate());
-        System.out.println("recommendCount " +recommendLogDocument.get().getRecommendCount());
     }
 
     @Test
@@ -301,7 +288,7 @@ public class WaybleZoneRecommendApiIntegrationTest {
                         .param("userId", String.valueOf(userId))
                         .param("latitude", String.valueOf(LATITUDE))
                         .param("longitude", String.valueOf(LONGITUDE))
-                        .param("count", String.valueOf(20))
+                        .param("size", String.valueOf(20))
                         .accept(MediaType.APPLICATION_JSON)
                 )
                 .andExpect(status().is2xxSuccessful())

--- a/src/test/java/com/wayble/server/explore/WaybleZoneRecommendApiIntegrationTest.java
+++ b/src/test/java/com/wayble/server/explore/WaybleZoneRecommendApiIntegrationTest.java
@@ -20,6 +20,7 @@ import com.wayble.server.user.entity.LoginType;
 import com.wayble.server.user.entity.User;
 import com.wayble.server.user.entity.UserType;
 import com.wayble.server.user.repository.UserRepository;
+import com.wayble.server.wayblezone.entity.WaybleZoneFacility;
 import com.wayble.server.wayblezone.entity.WaybleZoneType;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,6 +135,8 @@ public class WaybleZoneRecommendApiIntegrationTest {
                     .longitude(points.get("longitude"))
                     .build();
 
+            WaybleZoneFacility facility = createRandomFacility(i);
+            
             WaybleZoneDocumentRegisterDto dto = WaybleZoneDocumentRegisterDto
                     .builder()
                     .zoneId((long) i)
@@ -141,6 +144,7 @@ public class WaybleZoneRecommendApiIntegrationTest {
                     .address(address)
                     .thumbnailImageUrl("thumbnail url" + i)
                     .waybleZoneType(WaybleZoneType.values()[i % WaybleZoneType.values().length])
+                    .facility(facility)
                     .averageRating(Math.random() * 5)
                     .reviewCount((long)(Math.random() * 500))
                     .build();
@@ -264,6 +268,13 @@ public class WaybleZoneRecommendApiIntegrationTest {
         assertThat(dto.zoneType()).isNotNull();
         assertThat(dto.latitude()).isNotNull();
         assertThat(dto.longitude()).isNotNull();
+        assertThat(dto.facility()).isNotNull();
+        assertThat(dto.facility().hasSlope()).isNotNull();
+        assertThat(dto.facility().hasNoDoorStep()).isNotNull();
+        assertThat(dto.facility().hasElevator()).isNotNull();
+        assertThat(dto.facility().hasTableSeat()).isNotNull();
+        assertThat(dto.facility().hasDisabledToilet()).isNotNull();
+        assertThat(dto.facility().floorInfo()).isNotNull();
 
         System.out.println("zoneId = " + dto.zoneId());
         System.out.println("zoneName = " + dto.zoneName());
@@ -278,6 +289,17 @@ public class WaybleZoneRecommendApiIntegrationTest {
         System.out.println("similarityScore = " + dto.similarityScore());
         System.out.println("recencyScore = " + dto.recencyScore());
         System.out.println("totalScore = " + dto.totalScore());
+        System.out.println("=== Facility Info ===");
+        if (dto.facility() != null) {
+            System.out.println("hasSlope = " + dto.facility().hasSlope());
+            System.out.println("hasNoDoorStep = " + dto.facility().hasNoDoorStep());
+            System.out.println("hasElevator = " + dto.facility().hasElevator());
+            System.out.println("hasTableSeat = " + dto.facility().hasTableSeat());
+            System.out.println("hasDisabledToilet = " + dto.facility().hasDisabledToilet());
+            System.out.println("floorInfo = " + dto.facility().floorInfo());
+        } else {
+            System.out.println("facility info is null");
+        }
     }
 
     @Test
@@ -376,5 +398,20 @@ public class WaybleZoneRecommendApiIntegrationTest {
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);
 
         return start.plusDays(randomDays);
+    }
+    
+    private WaybleZoneFacility createRandomFacility(int i) {
+        Random random = new Random(i); // 시드 고정으로 재현 가능한 랜덤
+        
+        String[] floors = {"B1", "1층", "2층", "3층"};
+        
+        return WaybleZoneFacility.builder()
+                .hasSlope(random.nextBoolean())
+                .hasNoDoorStep(random.nextBoolean())
+                .hasElevator(random.nextBoolean())
+                .hasTableSeat(random.nextBoolean())
+                .hasDisabledToilet(random.nextBoolean())
+                .floorInfo(floors[random.nextInt(floors.length)])
+                .build();
     }
 }

--- a/src/test/java/com/wayble/server/explore/WaybleZoneSearchApiIntegrationTest.java
+++ b/src/test/java/com/wayble/server/explore/WaybleZoneSearchApiIntegrationTest.java
@@ -126,16 +126,14 @@ public class WaybleZoneSearchApiIntegrationTest {
     @Test
     public void checkDataExists() {
         List<WaybleZoneDocument> all = waybleZoneDocumentRepository.findAll();
-        System.out.println("=== 저장된 데이터 확인 ===");
-        System.out.println("Total documents: " + all.size());
+
 
         assertThat(all.size()).isGreaterThan(0);
+        System.out.println("Total documents: " + all.size());
         for (WaybleZoneDocument doc : all) {
             assertThat(doc.getZoneId()).isNotNull();
             assertThat(doc.getZoneName()).isNotNull();
             assertThat(doc.getAddress().getLocation()).isNotNull();
-            System.out.println("존 정보: " + doc.toString());
-            System.out.println("주소: " + doc.getAddress().toString());
         }
     }
 

--- a/src/test/java/com/wayble/server/explore/WaybleZoneSearchApiIntegrationTest.java
+++ b/src/test/java/com/wayble/server/explore/WaybleZoneSearchApiIntegrationTest.java
@@ -14,6 +14,7 @@ import com.wayble.server.user.entity.LoginType;
 import com.wayble.server.user.entity.User;
 import com.wayble.server.user.entity.UserType;
 import com.wayble.server.user.repository.UserRepository;
+import com.wayble.server.wayblezone.entity.WaybleZoneFacility;
 import com.wayble.server.wayblezone.entity.WaybleZoneType;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -102,12 +103,15 @@ public class WaybleZoneSearchApiIntegrationTest {
                     .longitude(points.get("longitude"))
                     .build();
 
+            WaybleZoneFacility facility = createRandomFacility(i);
+            
             WaybleZoneDocumentRegisterDto dto = WaybleZoneDocumentRegisterDto
                     .builder()
                     .zoneId((long) i)
                     .zoneName(nameList.get((int) (Math.random() * nameList.size())))
                     .address(address)
                     .waybleZoneType(WaybleZoneType.values()[i % WaybleZoneType.values().length])
+                    .facility(facility)
                     .averageRating(Math.random() * 5)
                     .reviewCount((long)(Math.random() * 500))
                     .build();
@@ -178,10 +182,33 @@ public class WaybleZoneSearchApiIntegrationTest {
                                 dto.distance(), dtoList.get(i-1).distance())
                         .isGreaterThanOrEqualTo(dtoList.get(i - 1).distance());
             }
+            
+            // facility 검증 추가
+            assertThat(dto.facility()).isNotNull();
+            assertThat(dto.facility().hasSlope()).isNotNull();
+            assertThat(dto.facility().hasNoDoorStep()).isNotNull();
+            assertThat(dto.facility().hasElevator()).isNotNull();
+            assertThat(dto.facility().hasTableSeat()).isNotNull();
+            assertThat(dto.facility().hasDisabledToilet()).isNotNull();
+            assertThat(dto.facility().floorInfo()).isNotNull();
         }
 
-        for (WaybleZoneSearchResponseDto dto : dtoList) {
-            System.out.println(dto.toString());
+
+        if (!dtoList.isEmpty()) {
+            WaybleZoneSearchResponseDto firstDto = dtoList.get(0);
+            System.out.println("=== Search Result - Facility Info ===");
+            System.out.println("zoneId = " + firstDto.zoneId());
+            System.out.println("zoneName = " + firstDto.zoneName());
+            if (firstDto.facility() != null) {
+                System.out.println("hasSlope = " + firstDto.facility().hasSlope());
+                System.out.println("hasNoDoorStep = " + firstDto.facility().hasNoDoorStep());
+                System.out.println("hasElevator = " + firstDto.facility().hasElevator());
+                System.out.println("hasTableSeat = " + firstDto.facility().hasTableSeat());
+                System.out.println("hasDisabledToilet = " + firstDto.facility().hasDisabledToilet());
+                System.out.println("floorInfo = " + firstDto.facility().floorInfo());
+            } else {
+                System.out.println("facility info is null");
+            }
         }
     }
 
@@ -389,6 +416,21 @@ public class WaybleZoneSearchApiIntegrationTest {
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);
 
         return start.plusDays(randomDays);
+    }
+    
+    private WaybleZoneFacility createRandomFacility(int i) {
+        Random random = new Random(i); // 시드 고정으로 재현 가능한 랜덤
+        
+        String[] floors = {"B1", "1층", "2층", "3층"};
+        
+        return WaybleZoneFacility.builder()
+                .hasSlope(random.nextBoolean())
+                .hasNoDoorStep(random.nextBoolean())
+                .hasElevator(random.nextBoolean())
+                .hasTableSeat(random.nextBoolean())
+                .hasDisabledToilet(random.nextBoolean())
+                .floorInfo(floors[random.nextInt(floors.length)])
+                .build();
     }
 }
 

--- a/src/test/java/com/wayble/server/explore/WaybleZoneSearchApiIntegrationTest.java
+++ b/src/test/java/com/wayble/server/explore/WaybleZoneSearchApiIntegrationTest.java
@@ -144,7 +144,7 @@ public class WaybleZoneSearchApiIntegrationTest {
     @Test
     @DisplayName("좌표를 전달받아 반경 이내의 웨이블 존을 거리 순으로 조회")
     public void findWaybleZoneByDistanceAscending() throws Exception{
-        MvcResult result = mockMvc.perform(get(baseUrl)
+        MvcResult result = mockMvc.perform(get(baseUrl + "/maps")
                         .header("Authorization", "Bearer " + token)
                         .param("latitude",  String.valueOf(LATITUDE))
                         .param("longitude", String.valueOf(LONGITUDE))
@@ -216,7 +216,7 @@ public class WaybleZoneSearchApiIntegrationTest {
     @DisplayName("특정 단어가 포함된 웨이블존을 거리 순으로 반환")
     public void findWaybleZoneByNameAscending() throws Exception{
         final String word = nameList.get((int) (Math.random() * nameList.size())).substring(0, 2);
-        MvcResult result = mockMvc.perform(get(baseUrl)
+        MvcResult result = mockMvc.perform(get(baseUrl + "/maps")
                         .header("Authorization", "Bearer " + token)
                         .param("latitude",  String.valueOf(LATITUDE))
                         .param("longitude", String.valueOf(LONGITUDE))
@@ -270,7 +270,7 @@ public class WaybleZoneSearchApiIntegrationTest {
     @DisplayName("특정 타입의 웨이블존을 거리 순으로 반환")
     public void findWaybleZoneByZoneTypeAscending() throws Exception{
         final WaybleZoneType zoneType = WaybleZoneType.CAFE;
-        MvcResult result = mockMvc.perform(get(baseUrl)
+        MvcResult result = mockMvc.perform(get(baseUrl + "/maps")
                         .header("Authorization", "Bearer " + token)
                         .param("latitude",  String.valueOf(LATITUDE))
                         .param("longitude", String.valueOf(LONGITUDE))
@@ -325,7 +325,7 @@ public class WaybleZoneSearchApiIntegrationTest {
     public void findWaybleZoneByNameAndZoneTypeAscending() throws Exception{
         final String word = nameList.get((int) (Math.random() * nameList.size())).substring(0, 2);
         final WaybleZoneType zoneType = WaybleZoneType.CAFE;
-        MvcResult result = mockMvc.perform(get(baseUrl)
+        MvcResult result = mockMvc.perform(get(baseUrl + "/maps")
                         .header("Authorization", "Bearer " + token)
                         .param("latitude",  String.valueOf(LATITUDE))
                         .param("longitude", String.valueOf(LONGITUDE))


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #48 

## 📝 작업 내용

- 웨이블존 추천, 검색 응답 필드에 장애 시설 정보를 추가했습니다.
  - 테스트 코드를 통해 잘 반환하는 것을 확인했습니다.

- JWT 추가로 테스트 코드 api 요청 과정에서 문제가 발생해, 해당 오류를 해결했습니다

- 지도 기반 검색 기능의 엔드포인트를 /search/maps로 변경했습니다.
  - 향후 추가될 XX동 주변 TOP3 가게 조회 기능과 엔드포인트를 분리하기 위해 이렇게 변경했습니다.

- ci/cd test하다가 pr 꼬여서 다시 올립니당 ㅎ
