### PR TITLE
[feat] 유저 정보 등록 API 구현 

### DIFF
--- a/src/main/java/com/wayble/server/user/controller/UserController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserController.java
@@ -3,10 +3,12 @@ package com.wayble.server.user.controller;
 import com.wayble.server.common.config.security.jwt.JwtTokenProvider;
 import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.common.response.CommonResponse;
+import com.wayble.server.user.dto.UserInfoRegisterRequestDto;
 import com.wayble.server.user.dto.UserLoginRequestDto;
 import com.wayble.server.user.dto.UserRegisterRequestDto;
 import com.wayble.server.user.dto.token.TokenResponseDto;
 import com.wayble.server.user.exception.UserErrorCase;
+import com.wayble.server.user.service.UserInfoService;
 import com.wayble.server.user.service.UserService;
 import com.wayble.server.user.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +19,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -112,4 +116,25 @@ public class UserController {
         return CommonResponse.success("로그아웃에 성공하였습니다.");
     }
 
+    @PostMapping("/info")
+    @Operation(summary = "내 정보 등록", description = "유저의 상세 정보를 최초 1회 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 정보 등록 완료"),
+            @ApiResponse(responseCode = "400", description = "이미 등록된 정보가 있습니다."),
+            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    public CommonResponse<String> registerUserInfo(
+            @RequestBody @Valid UserInfoRegisterRequestDto req
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (!(authentication.getPrincipal() instanceof Long userId)) {
+            throw new ApplicationException(UserErrorCase.FORBIDDEN);
+        }
+
+        userInfoService.registerUserInfo(userId, req);
+        return CommonResponse.success("내 정보 등록 완료");
+    }
+
+    private final UserInfoService userInfoService;
 }

--- a/src/main/java/com/wayble/server/user/controller/UserController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserController.java
@@ -33,6 +33,7 @@ public class UserController {
     private final UserService userService;
     private final AuthService authService;
     private final JwtTokenProvider jwtProvider;
+    private final UserInfoService userInfoService;
 
     @PostMapping("/signup")
     @Operation(
@@ -135,6 +136,4 @@ public class UserController {
         userInfoService.registerUserInfo(userId, req);
         return CommonResponse.success("내 정보 등록 완료");
     }
-
-    private final UserInfoService userInfoService;
 }

--- a/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
@@ -1,0 +1,26 @@
+package com.wayble.server.user.dto;
+
+
+import com.wayble.server.user.entity.Gender;
+import com.wayble.server.user.entity.UserType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UserInfoRegisterRequestDto {
+    @NotBlank(message = "닉네임은 필수입니다.")
+    private String nickname;
+
+    @NotBlank(message = "생년월일은 필수입니다.")
+    private String birthDate; // YYYY-MM-DD
+
+    @NotNull(message = "성별은 필수입니다.")
+    private Gender gender;
+
+    @NotNull(message = "유저 타입은 필수입니다.")
+    private UserType userType;
+
+    private String disabilityType; // 장애 유형, (userType == DISABLED만 값 존재)
+    private String mobilityAid; // 이동보조수단, (userType == DISABLED만 값 존재)
+}

--- a/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
@@ -5,11 +5,13 @@ import com.wayble.server.user.entity.Gender;
 import com.wayble.server.user.entity.UserType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class UserInfoRegisterRequestDto {
     @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(max = 8, message = "닉네임은 8자 이하여야 합니다.")
     private String nickname;
 
     @NotBlank(message = "생년월일은 필수입니다.")

--- a/src/main/java/com/wayble/server/user/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserLoginRequestDto.java
@@ -6,9 +6,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UserLoginRequestDto(
-        @NotBlank(message = "이름 또는 닉네임은 필수입니다")
-        String name,
-
         @NotBlank(message = "이메일은 필수입니다")
         @Email(message = "유효한 이메일 형식이 아닙니다")
         String email,

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -53,10 +53,16 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "user_type", nullable = false)
-    private UserType userType;
+    private UserType userType; // DISABLED,COMPANION,GENERAL
 
     @Column(name = "profile_image_url")
     private String profileImageUrl;
+
+    @Column(name = "disability_type")
+    private String disabilityType; // 장애 유형 (발달장애,시각장애,지체장애,청각장애)
+
+    @Column(name = "mobility_aid")
+    private String mobilityAid; // 이동 보조 수단 (안내견,지팡이,동행인,휠체어)
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();
@@ -87,5 +93,21 @@ public class User extends BaseEntity {
 
     public void setNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void setDisabilityType(String disabilityType) {
+        this.disabilityType = disabilityType;
+    }
+    public void setMobilityAid(String mobilityAid) {
+        this.mobilityAid = mobilityAid;
+    }
+    public void setBirthDate(LocalDate birthDate) {
+        this.birthDate = birthDate;
+    }
+    public void setGender(Gender gender) {
+        this.gender = gender;
+    }
+    public void setUserType(UserType userType) {
+        this.userType = userType;
     }
 }

--- a/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
@@ -16,7 +16,8 @@ public enum UserErrorCase implements ErrorCase {
     INVALID_CREDENTIALS(400, 1006, "아이디 혹은 비밀번호가 잘못되었습니다."),
     FORBIDDEN(403, 1007, "권한이 없습니다."),
     KAKAO_AUTH_FAILED(401, 1008, "카카오 인증에 실패하였습니다."),
-    USER_INFO_ALREADY_EXISTS(400,1009, "이미 등록된 정보가 있습니다.");
+    USER_INFO_ALREADY_EXISTS(400,1009, "이미 등록된 정보가 있습니다."),
+    INVALID_BIRTH_DATE(400, 1010, "생년월일 형식이 올바르지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
@@ -15,7 +15,8 @@ public enum UserErrorCase implements ErrorCase {
     USER_ALREADY_EXISTS(400, 1005, "이미 존재하는 회원입니다."),
     INVALID_CREDENTIALS(400, 1006, "아이디 혹은 비밀번호가 잘못되었습니다."),
     FORBIDDEN(403, 1007, "권한이 없습니다."),
-    KAKAO_AUTH_FAILED(401, 1008, "카카오 인증에 실패하였습니다.");
+    KAKAO_AUTH_FAILED(401, 1008, "카카오 인증에 실패하였습니다."),
+    USER_INFO_ALREADY_EXISTS(400,1009, "이미 등록된 정보가 있습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/user/service/UserInfoService.java
+++ b/src/main/java/com/wayble/server/user/service/UserInfoService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +30,11 @@ public class UserInfoService {
         }
 
         user.setNickname(dto.getNickname());
-        user.setBirthDate(LocalDate.parse(dto.getBirthDate()));
+        try {
+            user.setBirthDate(LocalDate.parse(dto.getBirthDate()));
+        } catch (DateTimeParseException e) {
+            throw new ApplicationException(UserErrorCase.INVALID_BIRTH_DATE);
+        }
         user.setGender(dto.getGender());
         user.setUserType(dto.getUserType());
 

--- a/src/main/java/com/wayble/server/user/service/UserInfoService.java
+++ b/src/main/java/com/wayble/server/user/service/UserInfoService.java
@@ -1,0 +1,47 @@
+package com.wayble.server.user.service;
+
+
+import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.user.dto.UserInfoRegisterRequestDto;
+import com.wayble.server.user.entity.User;
+import com.wayble.server.user.entity.UserType;
+import com.wayble.server.user.exception.UserErrorCase;
+import com.wayble.server.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class UserInfoService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void registerUserInfo(Long userId, UserInfoRegisterRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+
+        // 이미 등록된 정보가 있으면 에러 처리
+        if (user.getNickname() != null) {
+            throw new ApplicationException(UserErrorCase.USER_INFO_ALREADY_EXISTS);
+        }
+
+        user.setNickname(dto.getNickname());
+        user.setBirthDate(LocalDate.parse(dto.getBirthDate()));
+        user.setGender(dto.getGender());
+        user.setUserType(dto.getUserType());
+
+        if (dto.getUserType() == UserType.DISABLED) {
+            // 장애 유형,이동보조수단 설정
+            user.setDisabilityType(dto.getDisabilityType());
+            user.setMobilityAid(dto.getMobilityAid());
+        } else {
+            user.setDisabilityType(null);
+            user.setMobilityAid(null);
+        }
+
+        userRepository.save(user);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#69 

## 📝 작업 내용
- 유저 정보 등록 API(/api/v1/users/info) 신규 구현했습니다.
- 정보 등록 시 사용자는 자신에게 맞는 닉네임, 생년월일, 성별, 유저 타입, 장애유형, 이동보조수단 을 입력합니다.
- 기존 회원가입 시점엔 이메일/비밀번호/로그인타입만 입력하고, 나머지 정보는 등록 API에서 별도로 저장합니다.
- 와이어프레임에 따라 User 엔티티에 disabilityType(장애 유형), mobilityAid(이동 보조 수단) 컬럼을 추가하였습니다.
- 기존 회원가입 로직이 이메일,비밀번호로만 가입되게 로직이 바뀌면서 로그인쪽도 필수 기입이던 닉네임 필드를 제거하였습니다. 
- 유저 정보 등록은 최초 1회만 등록 가능하며, 이후에 정보를 수정해야한다면 유저 정보 수정 API를 하나 더 구현해서 수정 할 수 있도록 할 예정입니다. 

## 스크린샷 (선택)
### 유저 정보 등록 성공
<img width="1464" height="944" alt="내정보등록성공(1)" src="https://github.com/user-attachments/assets/1db9eb52-943a-430c-af4d-9961bc324cc9" />

### 유저 정보 등록 실패 (이메일,비밀번호 이외에 닉네임,성별,생년월일,유저타입 등 하나라도 등록이 되어있으면 400 처리)
<img width="1469" height="941" alt="유저정보등록실패(1)" src="https://github.com/user-attachments/assets/0abefbf8-8713-4ebd-87f3-3ae8d67f6592" />


## 💬 리뷰 요구사항 (선택)
> 아직 얘기가 나오진 않았지만 유저 정보 등록 이후에 해당 정보를 수정할 수 있는 유저 정보 수정 API가 필요해서 해당 API를 구현할 계획입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 상세 정보를 한 번만 등록할 수 있는 신규 등록 엔드포인트가 추가되었습니다.
  * 사용자 정보 등록 시 장애 유형 및 보조기구 정보 입력이 가능해졌습니다. (해당되는 경우)
* **버그 수정**
  * 로그인 시 더 이상 이름(닉네임) 입력이 필요하지 않습니다.
* **기타**
  * 이미 등록된 정보가 있을 경우 관련 오류 메시지가 추가되었습니다.
  * 생년월일 형식 오류에 대한 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->