### PR TITLE
[feat] 유저 정보 수정 API 구현 

### DIFF
--- a/src/main/java/com/wayble/server/user/controller/UserController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.wayble.server.common.config.security.jwt.JwtTokenProvider;
 import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.common.response.CommonResponse;
 import com.wayble.server.user.dto.UserInfoRegisterRequestDto;
+import com.wayble.server.user.dto.UserInfoUpdateRequestDto;
 import com.wayble.server.user.dto.UserLoginRequestDto;
 import com.wayble.server.user.dto.UserRegisterRequestDto;
 import com.wayble.server.user.dto.token.TokenResponseDto;
@@ -135,5 +136,29 @@ public class UserController {
 
         userInfoService.registerUserInfo(userId, req);
         return CommonResponse.success("내 정보 등록 완료");
+    }
+
+    @PatchMapping("/info")
+    @Operation(
+            summary = "내 정보 수정",
+            description = "유저가 자신의 정보를 수정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 정보 수정 완료"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "403", description = "권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
+    })
+    public CommonResponse<String> updateUserInfo(
+            @RequestBody @Valid UserInfoUpdateRequestDto dto
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (!(authentication.getPrincipal() instanceof Long)) {
+            throw new ApplicationException(UserErrorCase.FORBIDDEN);
+        }
+        Long userId = (Long) authentication.getPrincipal();
+
+        userInfoService.updateUserInfo(userId, dto);
+        return CommonResponse.success("내 정보 수정 완료");
     }
 }

--- a/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package com.wayble.server.user.dto;
+
+import com.wayble.server.user.entity.Gender;
+import com.wayble.server.user.entity.UserType;
+import lombok.Getter;
+
+@Getter
+public class UserInfoUpdateRequestDto {
+    private String nickname;         // 변경할 닉네임 (nullable)
+    private String birthDate;        // YYYY-MM-DD (nullable)
+    private Gender gender;           // MALE, FEMALE, UNKNOWN (nullable)
+    private UserType userType;       // GENERAL, DISABLED, COMPANION (nullable)
+    private String disabilityType;   // userType이 DISABLED일 때만 값, 아니면 null
+    private String mobilityAid;      // userType이 DISABLED일 때만 값, 아니면 null
+}

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -95,19 +95,13 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void setDisabilityType(String disabilityType) {
-        this.disabilityType = disabilityType;
-    }
-    public void setMobilityAid(String mobilityAid) {
-        this.mobilityAid = mobilityAid;
-    }
-    public void setBirthDate(LocalDate birthDate) {
-        this.birthDate = birthDate;
-    }
-    public void setGender(Gender gender) {
-        this.gender = gender;
-    }
-    public void setUserType(UserType userType) {
-        this.userType = userType;
-    }
+    public void setDisabilityType(String disabilityType) { this.disabilityType = disabilityType; }
+
+    public void setMobilityAid(String mobilityAid) { this.mobilityAid = mobilityAid; }
+
+    public void setBirthDate(LocalDate birthDate) { this.birthDate = birthDate; }
+
+    public void setGender(Gender gender) { this.gender = gender; }
+
+    public void setUserType(UserType userType) { this.userType = userType;}
 }

--- a/src/main/java/com/wayble/server/user/service/UserInfoService.java
+++ b/src/main/java/com/wayble/server/user/service/UserInfoService.java
@@ -3,6 +3,7 @@ package com.wayble.server.user.service;
 
 import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.user.dto.UserInfoRegisterRequestDto;
+import com.wayble.server.user.dto.UserInfoUpdateRequestDto;
 import com.wayble.server.user.entity.User;
 import com.wayble.server.user.entity.UserType;
 import com.wayble.server.user.exception.UserErrorCase;
@@ -45,6 +46,40 @@ public class UserInfoService {
         } else {
             user.setDisabilityType(null);
             user.setMobilityAid(null);
+        }
+
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void updateUserInfo(Long userId, UserInfoUpdateRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+
+        if (dto.getNickname() != null) {
+            user.setNickname(dto.getNickname());
+        }
+
+        // 생년월일 수정
+        if (dto.getBirthDate() != null) {
+            user.setBirthDate(LocalDate.parse(dto.getBirthDate()));
+        }
+
+        // 성별 수정
+        if (dto.getGender() != null) {
+            user.setGender(dto.getGender());
+        }
+
+        // 유저 타입 수정
+        if (dto.getUserType() != null) {
+            user.setUserType(dto.getUserType());
+            if (dto.getUserType() == UserType.DISABLED) {
+                user.setDisabilityType(dto.getDisabilityType());
+                user.setMobilityAid(dto.getMobilityAid());
+            } else {
+                user.setDisabilityType(null);
+                user.setMobilityAid(null);
+            }
         }
 
         userRepository.save(user);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#73 

## 📝 작업 내용
- 유저 정보 수정 API (/api/v1/users/info) 를 구현하였습니다. (HTTP: PATCH)
- 로그인된 사용자 본인의 유저 정보 (닉네임, 생년월일, 성별, 유저 타입, 장애유형, 이동보조수단)에 대해서 수정이 가능합니다.
- 수정 시 DTO에 들어온 값만 선택적으로 업데이트하도록 처리하였습니다. (null이면 변경X)

## 🖼️ 스크린샷 (선택)
<img width="1455" height="946" alt="내정보수정완료(1)" src="https://github.com/user-attachments/assets/85fd4de8-4b3a-4f83-9e78-c0eb897300cf" />


## 💬 리뷰 요구사항 (선택)
> 아마 유저 정보 등록 및 수정에서 유저의 실제 이름을 등록 및 수정하는 로직도 필요할 것 같아서 프론트분들과 상의 해보고 추후에 리팩토링 하겠습니다.

