### PR TITLE
[feat] 웨이블존 MySQL<->Elastic Search 동기화 기능 구현 완료

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -4,7 +4,7 @@ on:
   #    push:
   #      branches: [ "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "feature/seungmin" ]
 
 permissions:
   contents: read
@@ -180,23 +180,23 @@ jobs:
             exit 1
           fi
 
-      # ✅ 배포 성공 알림 (Discord)
-      - name: Send success webhook to Discord
-        if: success()
-        run: |
-          curl -H "Content-Type: application/json" \
-               -X POST \
-               -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: develop)\"}" \
-               ${{ secrets.DISCORD_WEBHOOK_URL }}
-
-      # ❌ 배포 실패 알림 (Discord)
-      - name: Send failure webhook to Discord
-        if: failure()
-        run: |
-          curl -H "Content-Type: application/json" \
-               -X POST \
-               -d "{\"content\": \"❌ EC2 배포 실패! 확인이 필요합니다.\"}" \
-               ${{ secrets.DISCORD_WEBHOOK_URL }}
+#      # ✅ 배포 성공 알림 (Discord)
+#      - name: Send success webhook to Discord
+#        if: success()
+#        run: |
+#          curl -H "Content-Type: application/json" \
+#               -X POST \
+#               -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: develop)\"}" \
+#               ${{ secrets.DISCORD_WEBHOOK_URL }}
+#
+#      # ❌ 배포 실패 알림 (Discord)
+#      - name: Send failure webhook to Discord
+#        if: failure()
+#        run: |
+#          curl -H "Content-Type: application/json" \
+#               -X POST \
+#               -d "{\"content\": \"❌ EC2 배포 실패! 확인이 필요합니다.\"}" \
+#               ${{ secrets.DISCORD_WEBHOOK_URL }}
 
 
 

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -1,10 +1,10 @@
 name: CI/CD
 
 on:
-  #    push:
-  #      branches: [ "develop" ]
-  pull_request:
+  push:
     branches: [ "feature/seungmin" ]
+  pull_request:
+    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -101,7 +101,7 @@ jobs:
             -e "xpack.security.enabled=false" \
             -e "network.host=0.0.0.0" \
             -e "ES_JAVA_OPTS=-Xms384m -Xmx384m" \
-            -v elasticsearch-data:/usr/share/elasticsearch/data \ 
+            -v elasticsearch-data:/usr/share/elasticsearch/data \
             es-with-nori:9.0.2
 
       - name: Wait for test Elasticsearch to be ready

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -180,23 +180,23 @@ jobs:
             exit 1
           fi
 
-#      # ✅ 배포 성공 알림 (Discord)
-#      - name: Send success webhook to Discord
-#        if: success()
-#        run: |
-#          curl -H "Content-Type: application/json" \
-#               -X POST \
-#               -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: develop)\"}" \
-#               ${{ secrets.DISCORD_WEBHOOK_URL }}
-#
-#      # ❌ 배포 실패 알림 (Discord)
-#      - name: Send failure webhook to Discord
-#        if: failure()
-#        run: |
-#          curl -H "Content-Type: application/json" \
-#               -X POST \
-#               -d "{\"content\": \"❌ EC2 배포 실패! 확인이 필요합니다.\"}" \
-#               ${{ secrets.DISCORD_WEBHOOK_URL }}
+      # ✅ 배포 성공 알림 (Discord)
+      - name: Send success webhook to Discord
+        if: success()
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: develop)\"}" \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+      # ❌ 배포 실패 알림 (Discord)
+      - name: Send failure webhook to Discord
+        if: failure()
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\": \"❌ EC2 배포 실패! 확인이 필요합니다.\"}" \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}
 
 
 

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -1,8 +1,8 @@
 name: CI/CD
 
 on:
-  push:
-    branches: [ "feature/seungmin" ]
+#  push:
+#    branches: [ "develop" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -101,6 +101,7 @@ jobs:
             -e "xpack.security.enabled=false" \
             -e "network.host=0.0.0.0" \
             -e "ES_JAVA_OPTS=-Xms384m -Xmx384m" \
+            -v elasticsearch-data:/usr/share/elasticsearch/data \ 
             es-with-nori:9.0.2
 
       - name: Wait for test Elasticsearch to be ready

--- a/src/main/java/com/wayble/server/ServerApplication.java
+++ b/src/main/java/com/wayble/server/ServerApplication.java
@@ -8,11 +8,13 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(
 		exclude = ReactiveElasticsearchRepositoriesAutoConfiguration.class
 )
 @EnableJpaAuditing
+@EnableScheduling
 @EnableElasticsearchRepositories(basePackages = "com.wayble.server.explore.repository")
 @EnableConfigurationProperties(TMapProperties.class)
 @EntityScan(basePackages = "com.wayble.server")

--- a/src/main/java/com/wayble/server/explore/entity/WaybleZoneDocument.java
+++ b/src/main/java/com/wayble/server/explore/entity/WaybleZoneDocument.java
@@ -48,8 +48,8 @@ public class WaybleZoneDocument {
                 .thumbnailImageUrl(waybleZone.getMainImageUrl() != null ? waybleZone.getMainImageUrl() : null)   // TODO: 이미지 경로 추가
                 .address(EsAddress.from(waybleZone.getAddress()))
                 .facility(EsWaybleZoneFacility.from(waybleZone.getFacility()))
-                .averageRating(0.0)
-                .reviewCount(0)
+                .averageRating(waybleZone.getRating())
+                .reviewCount(waybleZone.getReviewCount())
                 .build();
     }
 

--- a/src/main/java/com/wayble/server/review/service/ReviewService.java
+++ b/src/main/java/com/wayble/server/review/service/ReviewService.java
@@ -38,6 +38,8 @@ public class ReviewService {
         Review review = Review.of(user, zone, dto.content(), dto.rating());
         reviewRepository.save(review);
 
+        double newRating = ((zone.getRating() * zone.getReviewCount()) + dto.rating()) / (zone.getReviewCount() + 1);
+        zone.updateRating(newRating);
         zone.addReviewCount(1);
 
         if (dto.images() != null) {
@@ -45,7 +47,7 @@ public class ReviewService {
                 reviewImageRepository.save(ReviewImage.of(review, imageUrl));
             }
         }
-
+        waybleZoneRepository.save(zone);
 
         // visitDate 및 facilities 저장은 필요시 추가 구현
     }

--- a/src/main/java/com/wayble/server/wayblezone/repository/WaybleZoneRepositoryCustom.java
+++ b/src/main/java/com/wayble/server/wayblezone/repository/WaybleZoneRepositoryCustom.java
@@ -1,7 +1,9 @@
 package com.wayble.server.wayblezone.repository;
 
 import com.wayble.server.explore.dto.search.response.WaybleZoneDistrictResponseDto;
+import com.wayble.server.wayblezone.entity.WaybleZone;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface WaybleZoneRepositoryCustom {
@@ -9,4 +11,8 @@ public interface WaybleZoneRepositoryCustom {
     List<WaybleZoneDistrictResponseDto> findTop3likesWaybleZonesByDistrict(String district);
 
     List<WaybleZoneDistrictResponseDto> findTop3SearchesWaybleZonesByDistrict(String district);
+    
+    // ES 동기화 관련 메서드들
+    List<WaybleZone> findUnsyncedZones(int limit);
+    List<WaybleZone> findZonesModifiedAfter(LocalDateTime since, int limit);
 }

--- a/src/main/java/com/wayble/server/wayblezone/repository/WaybleZoneRepositoryImpl.java
+++ b/src/main/java/com/wayble/server/wayblezone/repository/WaybleZoneRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.wayble.server.explore.dto.search.response.WaybleZoneDistrictResponseD
 import com.wayble.server.explore.entity.EsWaybleZoneFacility;
 import com.wayble.server.wayblezone.entity.WaybleZone;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -103,6 +104,25 @@ public class WaybleZoneRepositoryImpl implements WaybleZoneRepositoryCustom {
                             .build();
                 })
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<WaybleZone> findUnsyncedZones(int limit) {
+        return queryFactory
+                .selectFrom(waybleZone)
+                .where(waybleZone.syncedAt.isNull()
+                       .or(waybleZone.lastModifiedAt.gt(waybleZone.syncedAt)))
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<WaybleZone> findZonesModifiedAfter(LocalDateTime since, int limit) {
+        return queryFactory
+                .selectFrom(waybleZone)
+                .where(waybleZone.lastModifiedAt.gt(since))
+                .limit(limit)
+                .fetch();
     }
 
     // 내부 클래스로 visit count 담을 DTO

--- a/src/main/java/com/wayble/server/wayblezone/sync/WaybleZoneSyncScheduler.java
+++ b/src/main/java/com/wayble/server/wayblezone/sync/WaybleZoneSyncScheduler.java
@@ -1,0 +1,35 @@
+package com.wayble.server.wayblezone.sync;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WaybleZoneSyncScheduler {
+
+    private final WaybleZoneSyncService waybleZoneSyncService;
+
+    @Scheduled(cron = "0 0 2 * * ?")    // 매일 새벽 2시 실행
+    //@Scheduled(cron = "0 38 21 * * ?") // 매일 오후 9시 30분 실행 (테스트용)
+    public void scheduleWaybleZoneSync() {
+        log.info("WaybleZone 정기 동기화 시작");
+        
+        try {
+            WaybleZoneSyncService.SyncResult result = waybleZoneSyncService.syncUnsyncedZones();
+            
+            if (result.isSuccessful()) {
+                log.info("WaybleZone 정기 동기화 성공 - 동기화된 항목: {}, 소요시간: {}ms", 
+                        result.getSyncedCount(), result.getDurationMs());
+            } else {
+                log.warn("WaybleZone 정기 동기화 부분 실패 - 성공: {}, 실패: {}, 소요시간: {}ms",
+                        result.getSyncedCount(), result.getFailedCount(), result.getDurationMs());
+            }
+            
+        } catch (Exception e) {
+            log.error("WaybleZone 정기 동기화 중 예상치 못한 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/wayble/server/wayblezone/sync/WaybleZoneSyncService.java
+++ b/src/main/java/com/wayble/server/wayblezone/sync/WaybleZoneSyncService.java
@@ -1,0 +1,164 @@
+package com.wayble.server.wayblezone.sync;
+
+import com.wayble.server.explore.entity.WaybleZoneDocument;
+import com.wayble.server.explore.repository.WaybleZoneDocumentRepository;
+import com.wayble.server.wayblezone.entity.WaybleZone;
+import com.wayble.server.wayblezone.repository.WaybleZoneRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WaybleZoneSyncService {
+
+    private final WaybleZoneRepository waybleZoneRepository;
+    private final WaybleZoneDocumentRepository waybleZoneDocumentRepository;
+
+    private static final int BATCH_SIZE = 100;
+    private static final int MAX_RETRY_ATTEMPTS = 3;
+
+    @Transactional
+    public SyncResult syncUnsyncedZones() {
+        log.info("동기화되지 않은 WaybleZone 동기화 시작");
+        
+        int totalSynced = 0;
+        int totalFailed = 0;
+        LocalDateTime syncStartTime = LocalDateTime.now();
+        
+        List<WaybleZone> unsyncedZones;
+        while (!(unsyncedZones = waybleZoneRepository.findUnsyncedZones(BATCH_SIZE)).isEmpty()) {
+            log.info("동기화 대상 {} 개 조회", unsyncedZones.size());
+            
+            for (WaybleZone zone : unsyncedZones) {
+                try {
+                    syncSingleZone(zone);
+                    totalSynced++;
+                    log.debug("Zone {} 동기화 완료", zone.getId());
+                } catch (Exception e) {
+                    totalFailed++;
+                    log.error("Zone {} 동기화 실패: {}", zone.getId(), e.getMessage(), e);
+                }
+            }
+        }
+        
+        LocalDateTime syncEndTime = LocalDateTime.now();
+        SyncResult result = new SyncResult(totalSynced, totalFailed, syncStartTime, syncEndTime);
+        
+        log.info("동기화 완료 - 성공: {}, 실패: {}, 소요시간: {}ms", 
+                totalSynced, totalFailed, result.getDurationMs());
+        
+        return result;
+    }
+
+    @Transactional
+    public SyncResult syncZonesModifiedAfter(LocalDateTime since) {
+        log.info("{} 이후 수정된 WaybleZone 동기화 시작", since);
+        
+        int totalSynced = 0;
+        int totalFailed = 0;
+        LocalDateTime syncStartTime = LocalDateTime.now();
+        
+        List<WaybleZone> modifiedZones;
+        while (!(modifiedZones = waybleZoneRepository.findZonesModifiedAfter(since, BATCH_SIZE)).isEmpty()) {
+            log.info("동기화 대상 {} 개 조회", modifiedZones.size());
+            
+            for (WaybleZone zone : modifiedZones) {
+                try {
+                    syncSingleZone(zone);
+                    totalSynced++;
+                    log.debug("Zone {} 동기화 완료", zone.getId());
+                } catch (Exception e) {
+                    totalFailed++;
+                    log.error("Zone {} 동기화 실패: {}", zone.getId(), e.getMessage(), e);
+                }
+            }
+        }
+        
+        LocalDateTime syncEndTime = LocalDateTime.now();
+        SyncResult result = new SyncResult(totalSynced, totalFailed, syncStartTime, syncEndTime);
+        
+        log.info("동기화 완료 - 성공: {}, 실패: {}, 소요시간: {}ms",
+                totalSynced, totalFailed, result.getDurationMs());
+        
+        return result;
+    }
+
+    private void syncSingleZone(WaybleZone zone) {
+        int attempts = 0;
+        Exception lastException = null;
+        
+        while (attempts < MAX_RETRY_ATTEMPTS) {
+            try {
+                attempts++;
+                
+                // WaybleZone을 WaybleZoneDocument로 변환하여 ES에 저장
+                WaybleZoneDocument document = WaybleZoneDocument.fromEntity(zone);
+                waybleZoneDocumentRepository.save(document);
+                
+                // MySQL에서 동기화 완료 표시
+                zone.markAsSynced();
+                waybleZoneRepository.save(zone);
+                
+                log.debug("Zone {} 동기화 성공 (시도: {})", zone.getId(), attempts);
+                return;
+                
+            } catch (OptimisticLockingFailureException e) {
+                lastException = e;
+                log.warn("Zone {} 동기화 중 OptimisticLockingFailure 발생 (시도: {})", zone.getId(), attempts);
+                
+                if (attempts < MAX_RETRY_ATTEMPTS) {
+                    try {
+                        Thread.sleep(100 * attempts); // 재시도 간격 증가
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("동기화 중 인터럽트 발생", ie);
+                    }
+                }
+            } catch (Exception e) {
+                lastException = e;
+                log.error("Zone {} 동기화 중 예상치 못한 오류 발생 (시도: {}): {}", 
+                         zone.getId(), attempts, e.getMessage());
+                break; // 재시도 불가능한 오류
+            }
+        }
+        
+        throw new RuntimeException(
+            String.format("Zone %d 동기화 실패 (최대 재시도 횟수 초과)", zone.getId()), 
+            lastException
+        );
+    }
+
+    public static class SyncResult {
+        private final int syncedCount;
+        private final int failedCount;
+        private final LocalDateTime startTime;
+        private final LocalDateTime endTime;
+
+        public SyncResult(int syncedCount, int failedCount, LocalDateTime startTime, LocalDateTime endTime) {
+            this.syncedCount = syncedCount;
+            this.failedCount = failedCount;
+            this.startTime = startTime;
+            this.endTime = endTime;
+        }
+
+        public int getSyncedCount() { return syncedCount; }
+        public int getFailedCount() { return failedCount; }
+        public LocalDateTime getStartTime() { return startTime; }
+        public LocalDateTime getEndTime() { return endTime; }
+        
+        public long getDurationMs() {
+            return java.time.Duration.between(startTime, endTime).toMillis();
+        }
+        
+        public boolean isSuccessful() {
+            return failedCount == 0;
+        }
+    }
+}


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #47

## 📝 작업 내용

- 웨이블존 엔티티 생성 혹은 리뷰 수, 리뷰 평점, 좋아요 수, 메인 이미지 등의 필드에 변경사항이 있을시 Elastic Search의 웨이블존 저장소에도 변경사항을 동기화하는 로직을 구현했습니다.
- Elastic Search는 생성, 수정 연산에 불리하기 때문에, 매일 새벽 2시에 24시간동안 있었던 변경사항을 한 번에 반영하도록 기능을 구현했습니다.
  - Spring Schduler를 사용해 기능을 구현했습니다.

### 스크린샷 (선택)
<img width="1468" height="147" alt="image" src="https://github.com/user-attachments/assets/0eb14181-ca25-4e9b-a684-d84d3253ba96" />

