### PR TITLE
[feat] 유저 정보 조회 API 구현 

### DIFF
--- a/src/main/java/com/wayble/server/user/controller/UserController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.wayble.server.user.controller;
 import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.common.response.CommonResponse;
 import com.wayble.server.user.dto.UserInfoRegisterRequestDto;
+import com.wayble.server.user.dto.UserInfoResponseDto;
 import com.wayble.server.user.dto.UserInfoUpdateRequestDto;
 import com.wayble.server.user.dto.UserRegisterRequestDto;
 import com.wayble.server.user.exception.UserErrorCase;
@@ -67,10 +68,7 @@ public class UserController {
     }
 
     @PatchMapping("/info")
-    @Operation(
-            summary = "내 정보 수정",
-            description = "유저가 자신의 정보를 수정합니다."
-    )
+    @Operation(summary = "내 정보 수정", description = "유저가 자신의 정보를 수정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "내 정보 수정 완료"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
@@ -88,5 +86,21 @@ public class UserController {
 
         userInfoService.updateUserInfo(userId, dto);
         return CommonResponse.success("내 정보 수정 완료");
+    }
+
+    @GetMapping("/info")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인된 유저의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 정보 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "유저 정보가 존재하지 않습니다."),
+            @ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    public CommonResponse<UserInfoResponseDto> getUserInfo() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (!(authentication.getPrincipal() instanceof Long userId)) {
+            throw new ApplicationException(UserErrorCase.FORBIDDEN);
+        }
+        UserInfoResponseDto info = userInfoService.getUserInfo(userId);
+        return CommonResponse.success(info);
     }
 }

--- a/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
@@ -26,5 +26,9 @@ public class UserInfoRegisterRequestDto {
     private UserType userType;
 
     private List<String> disabilityType; // 장애 유형, (userType == DISABLED만 값 존재)
+
     private List<String> mobilityAid;  // 이동보조수단, (userType == DISABLED만 값 존재)
+
+    // TODO: 현재 와이어프레임에 유저 이미지 등록하는 로직이 없어서 유저 정보 등록에서 이미지 등록 안하면 해당 필드 추후 삭제
+    private String profileImageUrl;
 }

--- a/src/main/java/com/wayble/server/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoResponseDto.java
@@ -1,0 +1,20 @@
+package com.wayble.server.user.dto;
+
+import com.wayble.server.user.entity.Gender;
+import com.wayble.server.user.entity.UserType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserInfoResponseDto {
+    private String nickname;
+    private String birthDate;
+    private Gender gender;
+    private UserType userType;
+    private List<String> disabilityType; // 복수 선택 가능
+    private List<String> mobilityAid;    // 복수 선택 가능
+    private String profileImageUrl;
+}

--- a/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
@@ -14,4 +14,5 @@ public class UserInfoUpdateRequestDto {
     private UserType userType;       // GENERAL, DISABLED, COMPANION (nullable)
     private List<String> disabilityType;  // userType이 DISABLED일 때만 값, 아니면 null
     private List<String> mobilityAid;      // userType이 DISABLED일 때만 값, 아니면 null
+    private String profileImageUrl; // TODO: 현재 와이어프레임에 유저 이미지 등록하는 로직이 없어서 유저 정보 등록에서 이미지 등록 안하면 해당 필드 추후 삭제
 }

--- a/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
@@ -17,7 +17,8 @@ public enum UserErrorCase implements ErrorCase {
     FORBIDDEN(403, 1007, "권한이 없습니다."),
     KAKAO_AUTH_FAILED(401, 1008, "카카오 인증에 실패하였습니다."),
     USER_INFO_ALREADY_EXISTS(400,1009, "이미 등록된 정보가 있습니다."),
-    INVALID_BIRTH_DATE(400, 1010, "생년월일 형식이 올바르지 않습니다.");
+    INVALID_BIRTH_DATE(400, 1010, "생년월일 형식이 올바르지 않습니다."),
+    USER_INFO_NOT_EXISTS(401,2002, "유저 정보가 존재하지 않습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/user/service/UserInfoService.java
+++ b/src/main/java/com/wayble/server/user/service/UserInfoService.java
@@ -39,6 +39,7 @@ public class UserInfoService {
         }
         user.setGender(dto.getGender());
         user.setUserType(dto.getUserType());
+        user.updateProfileImageUrl(dto.getProfileImageUrl());
 
         if (dto.getUserType() == UserType.DISABLED) {
             // 장애 유형,이동보조수단 설정
@@ -78,6 +79,11 @@ public class UserInfoService {
         // 유저 타입 수정
         if (dto.getUserType() != null) {
             user.setUserType(dto.getUserType());
+        }
+
+        // 유저 프로필 이미지 수정
+        if (dto.getProfileImageUrl() != null) {
+            user.updateProfileImageUrl(dto.getProfileImageUrl());
         }
 
         UserType finalUserType = dto.getUserType() != null ? dto.getUserType() : user.getUserType();

--- a/src/main/java/com/wayble/server/user/service/UserInfoService.java
+++ b/src/main/java/com/wayble/server/user/service/UserInfoService.java
@@ -3,6 +3,7 @@ package com.wayble.server.user.service;
 
 import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.user.dto.UserInfoRegisterRequestDto;
+import com.wayble.server.user.dto.UserInfoResponseDto;
 import com.wayble.server.user.dto.UserInfoUpdateRequestDto;
 import com.wayble.server.user.entity.User;
 import com.wayble.server.user.entity.UserType;
@@ -94,5 +95,23 @@ public class UserInfoService {
         }
 
         userRepository.save(user);
+    }
+
+    @Transactional
+    public UserInfoResponseDto getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+        if (user.getNickname() == null) {
+            throw new ApplicationException(UserErrorCase.USER_INFO_NOT_EXISTS);
+        }
+        return UserInfoResponseDto.builder()
+                .nickname(user.getNickname())
+                .birthDate(user.getBirthDate() != null ? user.getBirthDate().toString() : null)
+                .gender(user.getGender())
+                .userType(user.getUserType())
+                .disabilityType(user.getDisabilityType())
+                .mobilityAid(user.getMobilityAid())
+                .profileImageUrl(user.getProfileImageUrl())
+                .build();
     }
 }


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #89 

## 📝 작업 내용
- 유저 정보 조회 API 구현 (GET /api/v1/users/info)
- 인증된 유저의 상세 정보(닉네임, 생년월일, 성별, 유저타입, 장애유형, 이동보조수단, 프로필이미지) 조회 기능 추가
- 등록/수정/조회 시 profileImageUrl 필드를 반영할 수 있도록 추가  

## 🖼️ 스크린샷 (선택)
### 유저 정보 조회 성공
<img width="1462" height="948" alt="유저정보조회성공(1)" src="https://github.com/user-attachments/assets/bc012cf1-ba45-40bc-976f-4cb0687cefd0" />


## 💬 리뷰 요구사항 (선택)
> 프론트에서 작업하게 구현해달라고 해서 바로 main으로 넘기겠습니다. 