### PR TITLE
[refactor] 유저 장애유형,이동보조수단 enum 처리 및 유저 이미지 등록 관련 로직 주석 처리

### DIFF
--- a/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
@@ -1,7 +1,9 @@
 package com.wayble.server.user.dto;
 
 
+import com.wayble.server.user.entity.DisabilityType;
 import com.wayble.server.user.entity.Gender;
+import com.wayble.server.user.entity.MobilityAid;
 import com.wayble.server.user.entity.UserType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -26,9 +28,10 @@ public class UserInfoRegisterRequestDto {
     @NotNull(message = "유저 타입은 필수입니다.")
     private UserType userType;
 
-    private List<String> disabilityType; // 장애 유형, (userType == DISABLED만 값 존재)
 
-    private List<String> mobilityAid;  // 이동보조수단, (userType == DISABLED만 값 존재)
+    private List<DisabilityType> disabilityType; // 장애 유형, (userType == DISABLED만 값 존재)
+
+    private List<MobilityAid> mobilityAid;  // 이동보조수단, (userType == DISABLED만 값 존재)
 
     /* 유저 이미지 등록 관련 (추후에 사용할 수도 있어서 주석처리)
     @Pattern(regexp = "^(https?://).*", message = "올바른 URL 형식이어야 합니다.")

--- a/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
@@ -30,7 +30,8 @@ public class UserInfoRegisterRequestDto {
 
     private List<String> mobilityAid;  // 이동보조수단, (userType == DISABLED만 값 존재)
 
-    // TODO: 현재 와이어프레임에 유저 이미지 등록하는 로직이 없어서 유저 정보 등록에서 이미지 등록 안하면 해당 필드 추후 삭제
+    /* 유저 이미지 등록 관련 (추후에 사용할 수도 있어서 주석처리)
     @Pattern(regexp = "^(https?://).*", message = "올바른 URL 형식이어야 합니다.")
     private String profileImageUrl;
+     */
 }

--- a/src/main/java/com/wayble/server/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoResponseDto.java
@@ -1,6 +1,8 @@
 package com.wayble.server.user.dto;
 
+import com.wayble.server.user.entity.DisabilityType;
 import com.wayble.server.user.entity.Gender;
+import com.wayble.server.user.entity.MobilityAid;
 import com.wayble.server.user.entity.UserType;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +16,7 @@ public class UserInfoResponseDto {
     private String birthDate;
     private Gender gender;
     private UserType userType;
-    private List<String> disabilityType; // 복수 선택 가능
-    private List<String> mobilityAid;    // 복수 선택 가능
+    private List<DisabilityType> disabilityType; // 복수 선택 가능
+    private List<MobilityAid> mobilityAid;   // 복수 선택 가능
     // private String profileImageUrl; (추후 사용 가능)
 }

--- a/src/main/java/com/wayble/server/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoResponseDto.java
@@ -16,5 +16,5 @@ public class UserInfoResponseDto {
     private UserType userType;
     private List<String> disabilityType; // 복수 선택 가능
     private List<String> mobilityAid;    // 복수 선택 가능
-    private String profileImageUrl;
+    // private String profileImageUrl; (추후 사용 가능)
 }

--- a/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
@@ -1,6 +1,8 @@
 package com.wayble.server.user.dto;
 
+import com.wayble.server.user.entity.DisabilityType;
 import com.wayble.server.user.entity.Gender;
+import com.wayble.server.user.entity.MobilityAid;
 import com.wayble.server.user.entity.UserType;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -13,8 +15,8 @@ public class UserInfoUpdateRequestDto {
     private String birthDate;        // YYYY-MM-DD (nullable)
     private Gender gender;           // MALE, FEMALE, UNKNOWN (nullable)
     private UserType userType;       // GENERAL, DISABLED, COMPANION (nullable)
-    private List<String> disabilityType;  // userType이 DISABLED일 때만 값, 아니면 null
-    private List<String> mobilityAid;      // userType이 DISABLED일 때만 값, 아니면 null
+    private List<DisabilityType> disabilityType;  // userType이 DISABLED일 때만 값, 아니면 null
+    private List<MobilityAid> mobilityAid;     // userType이 DISABLED일 때만 값, 아니면 null
     /* 유저 이미지 수정 관련 (추후 사용 가능)
     @Pattern(regexp = "^(https?://).*", message = "올바른 URL 형식이어야 합니다.")
     private String profileImageUrl;

--- a/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
@@ -15,6 +15,8 @@ public class UserInfoUpdateRequestDto {
     private UserType userType;       // GENERAL, DISABLED, COMPANION (nullable)
     private List<String> disabilityType;  // userType이 DISABLED일 때만 값, 아니면 null
     private List<String> mobilityAid;      // userType이 DISABLED일 때만 값, 아니면 null
+    /* 유저 이미지 수정 관련 (추후 사용 가능)
     @Pattern(regexp = "^(https?://).*", message = "올바른 URL 형식이어야 합니다.")
-    private String profileImageUrl; // TODO: 현재 와이어프레임에 유저 이미지 등록하는 로직이 없어서 유저 정보 등록에서 이미지 등록 안하면 해당 필드 추후 삭제
+    private String profileImageUrl;
+     */
 }

--- a/src/main/java/com/wayble/server/user/entity/DisabilityType.java
+++ b/src/main/java/com/wayble/server/user/entity/DisabilityType.java
@@ -1,0 +1,8 @@
+package com.wayble.server.user.entity;
+
+public enum DisabilityType {
+    DEVELOPMENTAL,  // 발달장애
+    VISUAL,         // 시각장애
+    PHYSICAL,       // 지체장애
+    AUDITORY        // 청각장애
+}

--- a/src/main/java/com/wayble/server/user/entity/MobilityAid.java
+++ b/src/main/java/com/wayble/server/user/entity/MobilityAid.java
@@ -1,0 +1,8 @@
+package com.wayble.server.user.entity;
+
+public enum MobilityAid {
+    GUIDE_DOG,      // 안내견
+    CANE,           // 지팡이
+    WHEELCHAIR,     // 휠체어
+    NONE            // 없음
+}

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -1,6 +1,5 @@
 package com.wayble.server.user.entity;
 
-import com.wayble.server.common.converter.StringListConverter;
 import com.wayble.server.common.entity.BaseEntity;
 import com.wayble.server.review.entity.Review;
 import jakarta.persistence.*;

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -66,7 +66,7 @@ public class User extends BaseEntity {
 
     @Convert(converter = StringListConverter.class)
     @Column(name = "mobility_aid")
-    private List<String> mobilityAid;  // 이동 보조 수단 (안내견,지팡이,동행인,휠체어)
+    private List<String> mobilityAid;  // 이동 보조 수단 (안내견,지팡이,휠체어,없음)
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -126,7 +126,7 @@ public class User extends BaseEntity {
 
     public void setDisabilityType(List<DisabilityType> disabilityType) { this.disabilityType = disabilityType; }
 
-    public void setMobilityAid(List<DisabilityType> disabilityType) { this.mobilityAid = mobilityAid; }
+    public void setMobilityAid(List<MobilityAid> mobilityAid) { this.mobilityAid = mobilityAid; }
 
     public void setBirthDate(LocalDate birthDate) { this.birthDate = birthDate; }
 

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -59,14 +59,17 @@ public class User extends BaseEntity {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
-    @Convert(converter = StringListConverter.class)
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "user_disability_type", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
     @Column(name = "disability_type")
-    private List<String> disabilityType; // 장애 유형 (발달장애,시각장애,지체장애,청각장애)
+    private List<DisabilityType> disabilityType = new ArrayList<>(); // 장애 유형 (발달장애,시각장애,지체장애,청각장애)
 
-
-    @Convert(converter = StringListConverter.class)
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "user_mobility_aid", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
     @Column(name = "mobility_aid")
-    private List<String> mobilityAid;  // 이동 보조 수단 (안내견,지팡이,휠체어,없음)
+    private List<MobilityAid> mobilityAid = new ArrayList<>(); // 이동보조수단 (안내견,지팡이,휠체어,없음)
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();
@@ -121,9 +124,9 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void setDisabilityType(List<String> disabilityType) { this.disabilityType = disabilityType; }
+    public void setDisabilityType(List<DisabilityType> disabilityType) { this.disabilityType = disabilityType; }
 
-    public void setMobilityAid(List<String> mobilityAid) { this.mobilityAid = mobilityAid; }
+    public void setMobilityAid(List<DisabilityType> disabilityType) { this.mobilityAid = mobilityAid; }
 
     public void setBirthDate(LocalDate birthDate) { this.birthDate = birthDate; }
 

--- a/src/main/java/com/wayble/server/user/service/UserInfoService.java
+++ b/src/main/java/com/wayble/server/user/service/UserInfoService.java
@@ -39,7 +39,7 @@ public class UserInfoService {
         }
         user.setGender(dto.getGender());
         user.setUserType(dto.getUserType());
-        user.updateProfileImageUrl(dto.getProfileImageUrl());
+        // (추후 사용 가능) user.updateProfileImageUrl(dto.getProfileImageUrl());
 
         if (dto.getUserType() == UserType.DISABLED) {
             // 장애 유형,이동보조수단 설정
@@ -81,10 +81,11 @@ public class UserInfoService {
             user.setUserType(dto.getUserType());
         }
 
-        // 유저 프로필 이미지 수정
+        /* 유저 프로필 이미지 수정
         if (dto.getProfileImageUrl() != null) {
             user.updateProfileImageUrl(dto.getProfileImageUrl());
         }
+         */
 
         UserType finalUserType = dto.getUserType() != null ? dto.getUserType() : user.getUserType();
         if (finalUserType == UserType.DISABLED) {
@@ -117,7 +118,7 @@ public class UserInfoService {
                 .userType(user.getUserType())
                 .disabilityType(user.getDisabilityType())
                 .mobilityAid(user.getMobilityAid())
-                .profileImageUrl(user.getProfileImageUrl())
+                // (추후 사용 가능) .profileImageUrl(user.getProfileImageUrl())
                 .build();
     }
 }


### PR DESCRIPTION
## ✔️ 연관 이슈

- #79 

## 📝 작업 내용
- 유저 엔티티에 있는 장애유형(disabilityType), 이동보조수단(mobilityAid)을 String 타입으로 받던걸 enum으로 변경하고 관련 로직들을 수정했습니다. (현재 해당 필드들은 유형이 딱 정해져있기때문에 그냥 String보다 enum이 적합하다고 생각하였습니다.)
- 프론트분과 의논결과, 이미지 관련 로직은 후순위라고 하셔서 일단 로직에서 주석처리 하였습니다.
- 장애유형, 이동보조수단은 복수선택이 가능하도록 리스트로 만들고, 해당 필드들은 등록한 유저와 매핑하여 매핑테이블에 저장됩니다.

### 스크린샷 (선택)

## 리뷰요구사항
> 프론트분이 오늘 작업하고 있는 부분이라 바로 main으로 넘기겠습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 다양한 장애 유형과 이동 보조 수단을 선택할 수 있도록 장애 유형(DisabilityType) 및 이동 보조 수단(MobilityAid) 항목이 추가되었습니다.

* **리팩터링**
  * 사용자 정보 내 장애 유형과 이동 보조 수단 필드가 문자열 리스트에서 명확한 분류(enum) 타입 리스트로 변경되어, 선택 항목이 더욱 명확하게 표시됩니다.

* **기타**
  * 프로필 이미지 관련 기능이 추후 제공을 위해 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->