### PR TITLE
[refactor] 유저 정보 조회 필드 null 가능하도록 수정 + 유저 닉네임 중복 확인 API 관련 리팩토링 

### DIFF
--- a/src/main/java/com/wayble/server/auth/service/AuthService.java
+++ b/src/main/java/com/wayble/server/auth/service/AuthService.java
@@ -29,7 +29,7 @@ public class AuthService {
         if (!encoder.matches(req.password(), user.getPassword())) {
             throw new ApplicationException(UserErrorCase.INVALID_CREDENTIALS);
         }
-        String accessToken = jwtProvider.generateToken(user.getId(), user.getUserType().name());
+        String accessToken = jwtProvider.generateToken(user.getId(),user.getUserType() != null ? user.getUserType().name() : null);
         String refreshToken = jwtProvider.generateRefreshToken(user.getId());
         Long expiry = jwtProvider.getTokenExpiry(refreshToken);
 
@@ -72,7 +72,7 @@ public class AuthService {
         saved.setExpiry(newExpiry);
         refreshTokenRepository.save(saved);
 
-        String newAccessToken = jwtProvider.generateToken(userId, user.getUserType().name());
+        String newAccessToken = jwtProvider.generateToken(userId, user.getUserType() != null ? user.getUserType().name() : null);
         return new TokenResponseDto(newAccessToken, newRefreshToken);
     }
 

--- a/src/main/java/com/wayble/server/auth/service/KakaoLoginService.java
+++ b/src/main/java/com/wayble/server/auth/service/KakaoLoginService.java
@@ -60,7 +60,10 @@ public class KakaoLoginService {
         }
 
         // JWT 토큰 발급
-        String accessToken = jwtProvider.generateToken(user.getId(), user.getUserType().name());
+        String accessToken = jwtProvider.generateToken(
+                user.getId(),
+                user.getUserType() != null ? user.getUserType().name() : null
+        );
         String refreshToken = jwtProvider.generateRefreshToken(user.getId());
 
 

--- a/src/main/java/com/wayble/server/user/controller/UserController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserController.java
@@ -2,7 +2,11 @@ package com.wayble.server.user.controller;
 
 import com.wayble.server.common.exception.ApplicationException;
 import com.wayble.server.common.response.CommonResponse;
-import com.wayble.server.user.dto.*;
+import com.wayble.server.user.dto.UserInfoRegisterRequestDto;
+import com.wayble.server.user.dto.UserInfoUpdateRequestDto;
+import com.wayble.server.user.dto.UserInfoResponseDto;
+import com.wayble.server.user.dto.NicknameCheckResponse;
+import com.wayble.server.user.dto.UserRegisterRequestDto;
 import com.wayble.server.user.exception.UserErrorCase;
 import com.wayble.server.user.service.UserInfoService;
 import com.wayble.server.user.service.UserService;

--- a/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoRegisterRequestDto.java
@@ -7,7 +7,6 @@ import com.wayble.server.user.entity.MobilityAid;
 import com.wayble.server.user.entity.UserType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 

--- a/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserInfoUpdateRequestDto.java
@@ -4,7 +4,6 @@ import com.wayble.server.user.entity.DisabilityType;
 import com.wayble.server.user.entity.Gender;
 import com.wayble.server.user.entity.MobilityAid;
 import com.wayble.server.user.entity.UserType;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 import java.util.List;

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -59,13 +59,13 @@ public class User extends BaseEntity {
     private String profileImageUrl;
 
     @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "user_disability_type", joinColumns = @JoinColumn(name = "user_id"))
+    @CollectionTable(name = "user_disability_type_mapping", joinColumns = @JoinColumn(name = "user_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "disability_type")
     private List<DisabilityType> disabilityType = new ArrayList<>(); // 장애 유형 (발달장애,시각장애,지체장애,청각장애)
 
     @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "user_mobility_aid", joinColumns = @JoinColumn(name = "user_id"))
+    @CollectionTable(name = "user_mobility_aid_mapping", joinColumns = @JoinColumn(name = "user_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "mobility_aid")
     private List<MobilityAid> mobilityAid = new ArrayList<>(); // 이동보조수단 (안내견,지팡이,휠체어,없음)

--- a/src/main/java/com/wayble/server/user/entity/User.java
+++ b/src/main/java/com/wayble/server/user/entity/User.java
@@ -52,7 +52,7 @@ public class User extends BaseEntity {
     private LoginType loginType;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "user_type", nullable = false)
+    @Column(name = "user_type", nullable = true)
     private UserType userType; // DISABLED,COMPANION,GENERAL
 
     @Column(name = "profile_image_url")
@@ -89,7 +89,6 @@ public class User extends BaseEntity {
                 .email(email)
                 .password(password)
                 .loginType(loginType)
-                .userType(UserType.GENERAL) // 기본값
                 .build();
     }
 

--- a/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
@@ -3,7 +3,6 @@ package com.wayble.server.user.exception;
 import com.wayble.server.common.exception.ErrorCase;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/wayble/server/user/service/UserInfoService.java
+++ b/src/main/java/com/wayble/server/user/service/UserInfoService.java
@@ -108,9 +108,7 @@ public class UserInfoService {
     public UserInfoResponseDto getUserInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
-        if (user.getNickname() == null || user.getBirthDate() == null || user.getGender() == null) {
-            throw new ApplicationException(UserErrorCase.USER_INFO_NOT_EXISTS);
-        }
+
         return UserInfoResponseDto.builder()
                 .nickname(user.getNickname())
                 .birthDate(user.getBirthDate() != null ? user.getBirthDate().toString() : null)


### PR DESCRIPTION
## ✔️ 연관 이슈

- #92 

## 📝 작업 내용
1. 원래 로직은 회원가입(로그인) 후, 유저 정보 등록을 바로 가도록 구현하였습니다. 
2. 하지만 프론트쪽에서 로직이 바뀌어서, 로그인 후 정보 조회를 해보고 유저가 등록한 해당 정보가 없으면 유저 정보 등록으로 넘어가도록 수정하였습니다.
3. 때문에 원래는 유저 정보 조회에서 필드가 null이라면 에러 처리를 했지만, 유저 정보 조회에서 정보가 아무것도 없더라고 get으로 조회가 가능하도록 수정하였습니다.
4. 원래는 유저 타입을 기본값 GENERAL로 설정하였어서, 데이터 값이 비어있는지 여부 따라서 화면이 바뀌기때문에 해당 기본값을 NULL로 바꾸었고, 해당 수정으로 인해 바꿔야하는 부분도 수정하였습니다.
5. 코드리뷰(코드래빗)에 따라 유저 닉네임 중복 확인 관련 리팩토링을 진행하였습니다.

### 스크린샷 (선택)
> X