### PR TITLE
[feat] Discord Webhook 에러 알림 기능 구현

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           curl -H "Content-Type: application/json" \
                -X POST \
-               -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: develop)\"}" \
+               -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: main)\"}" \
                ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       # ❌ 배포 실패 알림 (Discord)

--- a/src/main/java/com/wayble/server/common/dto/DiscordWebhookPayload.java
+++ b/src/main/java/com/wayble/server/common/dto/DiscordWebhookPayload.java
@@ -1,0 +1,17 @@
+package com.wayble.server.common.dto;
+
+import java.util.List;
+
+public record DiscordWebhookPayload(
+        String content,
+        List<Embed> embeds
+) {
+    public record Embed(
+            String title,
+            String description,
+            String timestamp,
+            List<Field> fields
+    ) {
+        public record Field(String name, String value, boolean inline) {}
+    }
+}

--- a/src/main/java/com/wayble/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wayble/server/common/exception/GlobalExceptionHandler.java
@@ -1,16 +1,27 @@
 package com.wayble.server.common.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wayble.server.common.dto.DiscordWebhookPayload;
 import com.wayble.server.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.http.*;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 
+import java.time.Instant;
+import java.util.List;
+
+@Slf4j
 @ControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
@@ -19,11 +30,19 @@ public class GlobalExceptionHandler {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
+    @Value("${discord.webhook-url}")
+    private String discordWebhookUrl;
+
+    @Autowired
+    private Environment env;
+
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<CommonResponse> handleApplicationException(ApplicationException e, WebRequest request) {
         CommonResponse commonResponse = CommonResponse.error(e.getErrorCase());
 
         HttpStatus status = HttpStatus.valueOf(e.getErrorCase().getHttpStatusCode());
+        sendToDiscord(e, request, status);
+
         return ResponseEntity
                 .status(e.getErrorCase().getHttpStatusCode())
                 .body(commonResponse);
@@ -36,8 +55,47 @@ public class GlobalExceptionHandler {
         String message = bindingResult.getAllErrors().get(0).getDefaultMessage();
         CommonResponse commonResponse = CommonResponse.error(400, message);
 
+        sendToDiscord(ex, request, HttpStatus.BAD_REQUEST);
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(commonResponse);
+    }
+
+    private void sendToDiscord(Exception ex, WebRequest request, HttpStatus status) {
+        String path = ((ServletWebRequest) request).getRequest().getRequestURI();
+        String timestamp = Instant.now().toString();
+
+        if (!env.acceptsProfiles(Profiles.of("develop"))) {
+            log.debug("현재 active 프로파일이 develop가 아니므로 Discord 알림을 보내지 않습니다.");
+            return;
+        }
+
+        // Embed 필드 구성
+        DiscordWebhookPayload.Embed embed = new DiscordWebhookPayload.Embed(
+                "🚨 서버 에러 발생",
+                "```" + ex.getMessage() + "```",
+                timestamp,
+                List.of(
+                        new DiscordWebhookPayload.Embed.Field("URL", path, false),
+                        new DiscordWebhookPayload.Embed.Field("Status", status.toString(), true),
+                        new DiscordWebhookPayload.Embed.Field("Time", timestamp, true),
+                        new DiscordWebhookPayload.Embed.Field("Exception", ex.getClass().getSimpleName(), true)
+                )
+        );
+        DiscordWebhookPayload payload = new DiscordWebhookPayload(null, List.of(embed));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        try{
+            restTemplate.postForEntity(
+                    discordWebhookUrl,
+                    new HttpEntity<>(payload, headers),
+                    String.class
+            );
+            log.info("send to Discord webhook: {} complete", payload);
+        } catch (Exception e){
+            log.error(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/wayble/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wayble/server/common/exception/GlobalExceptionHandler.java
@@ -66,7 +66,7 @@ public class GlobalExceptionHandler {
         String timestamp = Instant.now().toString();
 
         if (!env.acceptsProfiles(Profiles.of("develop"))) {
-            log.debug("현재 active 프로파일이 develop가 아니므로 Discord 알림을 보내지 않습니다.");
+            log.info("현재 active 프로파일이 develop가 아니므로 Discord 알림을 보내지 않습니다.");
             return;
         }
 


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #102

## 📝 작업 내용

- 에러 발생 시 Discord Webhook 알림 전송 기능 구현
- 예외 로그 및, 발생 위치 정보를 포함합니다.
- EC2 배포 환경에서만 알림을 보내도록 기능을 구현했습니다.
  - 로컬 환경에서는 에러가 발생해도 알림이 가지 않습니다.

### 스크린샷 (선택)
<img width="610" height="514" alt="image" src="https://github.com/user-attachments/assets/86236384-86e4-4555-ac86-494ec65a0be9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 예외 발생 시 Discord 웹훅을 통해 오류 알림을 전송하는 기능이 추가되었습니다.

* **기타**
  * EC2 배포 성공 시 Discord 알림 메시지의 브랜치명이 "main"으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->