### PR TITLE
[fix] 배포 서버에서 로그인,유저 정보 조회 관련 에러 해결 

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -3,8 +3,11 @@ name: CI/CD
 on:
 #  push:
 #    branches: [ "feature/seungmin" ]
-  pull_request:
-    branches: [ "main" ]
+
+  push:
+    branches: [ "feature/seungin" ]
+#  pull_request:
+#    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -181,22 +184,22 @@ jobs:
           fi
 
       # ✅ 배포 성공 알림 (Discord)
-      - name: Send success webhook to Discord
-        if: success()
-        run: |
-          curl -H "Content-Type: application/json" \
-               -X POST \
-               -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: main)\"}" \
-               ${{ secrets.DISCORD_WEBHOOK_URL }}
+      #- name: Send success webhook to Discord
+      #  if: success()
+      #  run: |
+      #    curl -H "Content-Type: application/json" \
+      #         -X POST \
+      #         -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: main)\"}" \
+      #         ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       # ❌ 배포 실패 알림 (Discord)
-      - name: Send failure webhook to Discord
-        if: failure()
-        run: |
-          curl -H "Content-Type: application/json" \
-               -X POST \
-               -d "{\"content\": \"❌ EC2 배포 실패! 확인이 필요합니다.\"}" \
-               ${{ secrets.DISCORD_WEBHOOK_URL }}
+      #- name: Send failure webhook to Discord
+      #  if: failure()
+      #  run: |
+      #    curl -H "Content-Type: application/json" \
+      #         -X POST \
+      #         -d "{\"content\": \"❌ EC2 배포 실패! 확인이 필요합니다.\"}" \
+      #         ${{ secrets.DISCORD_WEBHOOK_URL }}
 
 
 

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -4,10 +4,10 @@ on:
 #  push:
 #    branches: [ "feature/seungmin" ]
 
-  push:
-    branches: [ "feature/seungin" ]
-#  pull_request:
-#    branches: [ "main" ]
+#push:
+#  branches: [ "feature/seungin" ]
+  pull_request:
+    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -184,22 +184,22 @@ jobs:
           fi
 
       # ✅ 배포 성공 알림 (Discord)
-      #- name: Send success webhook to Discord
-      #  if: success()
-      #  run: |
-      #    curl -H "Content-Type: application/json" \
-      #         -X POST \
-      #         -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: main)\"}" \
-      #         ${{ secrets.DISCORD_WEBHOOK_URL }}
+      - name: Send success webhook to Discord
+        if: success()
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: main)\"}" \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       # ❌ 배포 실패 알림 (Discord)
-      #- name: Send failure webhook to Discord
-      #  if: failure()
-      #  run: |
-      #    curl -H "Content-Type: application/json" \
-      #         -X POST \
-      #         -d "{\"content\": \"❌ EC2 배포 실패! 확인이 필요합니다.\"}" \
-      #         ${{ secrets.DISCORD_WEBHOOK_URL }}
+      - name: Send failure webhook to Discord
+        if: failure()
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\": \"❌ EC2 배포 실패! 확인이 필요합니다.\"}" \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}
 
 
 

--- a/src/main/java/com/wayble/server/auth/entity/RefreshToken.java
+++ b/src/main/java/com/wayble/server/auth/entity/RefreshToken.java
@@ -15,7 +15,7 @@ public class RefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true) // 1인 1토큰
+    @Column(name = "user_id", nullable = false, unique = true)
     private Long userId;
 
     @Column(nullable = false)

--- a/src/main/java/com/wayble/server/user/service/UserInfoService.java
+++ b/src/main/java/com/wayble/server/user/service/UserInfoService.java
@@ -109,6 +109,9 @@ public class UserInfoService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
 
+        user.getDisabilityType().size();
+        user.getMobilityAid().size();
+
         return UserInfoResponseDto.builder()
                 .nickname(user.getNickname())
                 .birthDate(user.getBirthDate() != null ? user.getBirthDate().toString() : null)


### PR DESCRIPTION
## ✔️ 연관 이슈
> X

## 📝 작업 내용
**1. 배포 서버에 로그인 관련 API에서 403 에러 발생하였습니다.**
- 해결: refreshtoken DB에 user_id와 userid 칼럼이 중복되어있어서 명시적으로 user_id 칼럼 지정해주고, 배포 DB에 userid 칼럼 삭제하여 해결

**2. 배포 서버에 유저 정보 조회 관련 API에서 조회시 403 에러 발생하였습니다. (JPA Lazy Loading + No session 문제)**
- 해결: 관련 필드(장애 유형,이동 보조 수단)에 .size()를 통해 트랜잭션 안에서 호출하여 JPA가 엔티티 리스트를 Lazy → Eager 하도록 설정하여 해결 
## 스크린샷 (선택)
### 배포 디비 refreshtoken 칼럼 정리
<img width="620" height="174" alt="문제해결2" src="https://github.com/user-attachments/assets/70b2872e-f190-45bf-a7c3-d2565954a9c6" />

### 유저 정보 조회 관련 403 에러 해결
<img width="1466" height="945" alt="화면 캡처 2025-08-06 193224" src="https://github.com/user-attachments/assets/00399cdf-04da-4a60-88d8-b98fa3b14457" />

### 리뷰 요구 사항 (선택)
> X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자 정보 조회 시 일부 정보가 올바르게 로딩되지 않던 문제를 해결했습니다.

* **기타**
  * 내부 데이터베이스 컬럼 이름 명시 및 워크플로우 설정 주석이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->