### PR TITLE
[feat] 관리자 페이지에 당일 가입자 수, 방문자 수 조회 로직 추가

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -1,8 +1,8 @@
 name: CI/CD
 
 on:
-#  push:
-#    branches: [ "feature/seungmin" ]
+  push:
+    branches: [ "feature/seungmin" ]
 
 #push:
 #  branches: [ "feature/seungin" ]

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -1,8 +1,8 @@
 name: CI/CD
 
 on:
-  push:
-    branches: [ "feature/seungmin" ]
+#  push:
+#    branches: [ "feature/seungmin" ]
 
 #push:
 #  branches: [ "feature/seungin" ]
@@ -189,7 +189,7 @@ jobs:
         run: |
           curl -H "Content-Type: application/json" \
                -X POST \
-               -d "{\"content\": \"✅ EC2 배포 성공! (브랜치: main)\"}" \
+               -d "{\"content\": \"✅ EC2 배포 성공!\"}" \
                ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       # ❌ 배포 실패 알림 (Discord)

--- a/src/main/java/com/wayble/server/ServerApplication.java
+++ b/src/main/java/com/wayble/server/ServerApplication.java
@@ -15,7 +15,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 )
 @EnableJpaAuditing
 @EnableScheduling
-@EnableElasticsearchRepositories(basePackages = "com.wayble.server.explore.repository")
+@EnableElasticsearchRepositories(basePackages = {"com.wayble.server.explore.repository", "com.wayble.server.logging.repository"})
 @EnableConfigurationProperties(TMapProperties.class)
 @EntityScan(basePackages = "com.wayble.server")
 public class ServerApplication {

--- a/src/main/java/com/wayble/server/admin/dto/DailyStatsDto.java
+++ b/src/main/java/com/wayble/server/admin/dto/DailyStatsDto.java
@@ -1,0 +1,15 @@
+package com.wayble.server.admin.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record DailyStatsDto(
+        LocalDate date,
+        long dailyRegistrationCount,
+        long dailyActiveUserCount,
+        long totalUserCount,
+        long totalWaybleZoneCount
+) {
+}

--- a/src/main/java/com/wayble/server/admin/service/AdminUserService.java
+++ b/src/main/java/com/wayble/server/admin/service/AdminUserService.java
@@ -165,8 +165,8 @@ public class AdminUserService {
         String email = (String) row[2];
         LocalDate birthDate = row[3] != null ? ((Date) row[3]).toLocalDate() : null;
         Gender gender = row[4] != null ? Gender.valueOf((String) row[4]) : null;
-        LoginType loginType = LoginType.valueOf((String) row[5]);
-        UserType userType = UserType.valueOf((String) row[6]);
+        LoginType loginType = row[5] != null ? LoginType.valueOf((String) row[5]) : null;
+        UserType userType = row[6] != null ? UserType.valueOf((String) row[6]) : null;
         String disabilityType = (String) row[7];
         String mobilityAid = (String) row[8];
         
@@ -181,8 +181,8 @@ public class AdminUserService {
         String email = (String) row[3];
         LocalDate birthDate = row[4] != null ? ((Date) row[4]).toLocalDate() : null;
         Gender gender = row[5] != null ? Gender.valueOf((String) row[5]) : null;
-        LoginType loginType = LoginType.valueOf((String) row[6]);
-        UserType userType = UserType.valueOf((String) row[7]);
+        LoginType loginType = row[6] != null ? LoginType.valueOf((String) row[6]) : null;
+        UserType userType = row[7] != null ? UserType.valueOf((String) row[7]) : null;
         String profileImageUrl = (String) row[8];
         String disabilityType = (String) row[9];
         String mobilityAid = (String) row[10];
@@ -203,8 +203,8 @@ public class AdminUserService {
         String email = (String) row[3];
         LocalDate birthDate = row[4] != null ? ((Date) row[4]).toLocalDate() : null;
         Gender gender = row[5] != null ? Gender.valueOf((String) row[5]) : null;
-        LoginType loginType = LoginType.valueOf((String) row[6]);
-        UserType userType = UserType.valueOf((String) row[7]);
+        LoginType loginType = row[6] != null ? LoginType.valueOf((String) row[6]) : null;
+        UserType userType = row[7] != null ? UserType.valueOf((String) row[7]) : null;
         String profileImageUrl = (String) row[8];
         String disabilityType = (String) row[9];
         String mobilityAid = (String) row[10];

--- a/src/main/java/com/wayble/server/auth/service/AuthService.java
+++ b/src/main/java/com/wayble/server/auth/service/AuthService.java
@@ -44,6 +44,12 @@ public class AuthService {
                 .build();
         refreshTokenRepository.save(entity);
 
+        // 첫 로그인시에도 활성 유저 로그 저장 (비동기, 하루 1회만)
+        userActionLogService.logTokenRefresh(
+                user.getId(), 
+                user.getUserType() != null ? user.getUserType().name() : null
+        );
+
         return new TokenResponseDto(accessToken, refreshToken);
     }
 

--- a/src/main/java/com/wayble/server/auth/service/AuthService.java
+++ b/src/main/java/com/wayble/server/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.wayble.server.auth.service;
 
 import com.wayble.server.common.config.security.jwt.JwtTokenProvider;
 import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.logging.service.UserActionLogService;
 import com.wayble.server.user.dto.UserLoginRequestDto;
 import com.wayble.server.auth.dto.TokenResponseDto;
 import com.wayble.server.auth.entity.RefreshToken;
@@ -22,6 +23,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder encoder;
     private final JwtTokenProvider jwtProvider;
+    private final UserActionLogService userActionLogService;
 
     public TokenResponseDto login(UserLoginRequestDto req) {
         User user = userRepository.findByEmailAndLoginType(req.email(), req.loginType())
@@ -73,6 +75,13 @@ public class AuthService {
         refreshTokenRepository.save(saved);
 
         String newAccessToken = jwtProvider.generateToken(userId, user.getUserType() != null ? user.getUserType().name() : null);
+        
+        // 토큰 갱신 로그 저장 (비동기, 하루 1회만)
+        userActionLogService.logTokenRefresh(
+                userId, 
+                user.getUserType() != null ? user.getUserType().name() : null
+        );
+        
         return new TokenResponseDto(newAccessToken, newRefreshToken);
     }
 

--- a/src/main/java/com/wayble/server/auth/service/KakaoLoginService.java
+++ b/src/main/java/com/wayble/server/auth/service/KakaoLoginService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wayble.server.common.config.security.jwt.JwtTokenProvider;
 import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.logging.service.UserActionLogService;
 import com.wayble.server.user.dto.KakaoLoginRequestDto;
 import com.wayble.server.user.dto.KakaoLoginResponseDto;
 import com.wayble.server.user.dto.KakaoUserInfoDto;
@@ -26,6 +27,7 @@ public class KakaoLoginService {
     private final JwtTokenProvider jwtProvider;
     private final ObjectMapper objectMapper;
     private final WebClient webClient;
+    private final UserActionLogService userActionLogService;
 
     private static final String KAKAO_USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
 
@@ -66,6 +68,14 @@ public class KakaoLoginService {
         );
         String refreshToken = jwtProvider.generateRefreshToken(user.getId());
 
+        // 신규 가입시에만 로그 저장 (비동기)
+        if (isNewUser) {
+            userActionLogService.logUserRegister(
+                    user.getId(), 
+                    LoginType.KAKAO.name(), 
+                    user.getUserType() != null ? user.getUserType().name() : null
+            );
+        }
 
         return KakaoLoginResponseDto.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/wayble/server/auth/service/KakaoLoginService.java
+++ b/src/main/java/com/wayble/server/auth/service/KakaoLoginService.java
@@ -68,14 +68,21 @@ public class KakaoLoginService {
         );
         String refreshToken = jwtProvider.generateRefreshToken(user.getId());
 
-        // 신규 가입시에만 로그 저장 (비동기)
+        // 로그 저장 (비동기)
         if (isNewUser) {
+            // 신규 가입 로그
             userActionLogService.logUserRegister(
                     user.getId(), 
                     LoginType.KAKAO.name(), 
                     user.getUserType() != null ? user.getUserType().name() : null
             );
         }
+        
+        // 모든 카카오 로그인시 활성 유저 로그 저장 (하루 1회만)
+        userActionLogService.logTokenRefresh(
+                user.getId(), 
+                user.getUserType() != null ? user.getUserType().name() : null
+        );
 
         return KakaoLoginResponseDto.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/wayble/server/logging/config/LoggingAsyncConfig.java
+++ b/src/main/java/com/wayble/server/logging/config/LoggingAsyncConfig.java
@@ -1,0 +1,26 @@
+package com.wayble.server.logging.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class LoggingAsyncConfig {
+    
+    @Bean("loggingTaskExecutor")
+    public Executor loggingTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("logging-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/wayble/server/logging/entity/UserActionLog.java
+++ b/src/main/java/com/wayble/server/logging/entity/UserActionLog.java
@@ -1,0 +1,46 @@
+package com.wayble.server.logging.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(indexName = "user_action_logs")
+public class UserActionLog {
+    
+    @Id
+    private String id;
+    
+    @Field(type = FieldType.Long)
+    private Long userId;
+    
+    @Field(type = FieldType.Keyword)
+    private String action;
+    
+    @Field(type = FieldType.Text)
+    private String userAgent;
+    
+    @Field(type = FieldType.Date)
+    private LocalDateTime timestamp;
+    
+    @Field(type = FieldType.Keyword)
+    private String loginType;
+    
+    @Field(type = FieldType.Keyword)
+    private String userType;
+    
+    public enum ActionType {
+        USER_REGISTER,
+        USER_TOKEN_REFRESH
+    }
+}

--- a/src/main/java/com/wayble/server/logging/repository/UserActionLogRepository.java
+++ b/src/main/java/com/wayble/server/logging/repository/UserActionLogRepository.java
@@ -1,0 +1,22 @@
+package com.wayble.server.logging.repository;
+
+import com.wayble.server.logging.entity.UserActionLog;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface UserActionLogRepository extends ElasticsearchRepository<UserActionLog, String> {
+    
+    List<UserActionLog> findByActionAndTimestampBetween(String action, LocalDateTime start, LocalDateTime end);
+    
+    List<UserActionLog> findByUserIdAndActionAndTimestampBetween(Long userId, String action, LocalDateTime start, LocalDateTime end);
+    
+    long countByActionAndTimestampBetween(String action, LocalDateTime start, LocalDateTime end);
+    
+    long countByUserIdAndActionAndTimestampBetween(Long userId, String action, LocalDateTime start, LocalDateTime end);
+    
+    long countDistinctUserIdByActionAndTimestampBetween(String action, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/wayble/server/logging/service/UserActionLogService.java
+++ b/src/main/java/com/wayble/server/logging/service/UserActionLogService.java
@@ -1,0 +1,105 @@
+package com.wayble.server.logging.service;
+
+import com.wayble.server.logging.entity.UserActionLog;
+import com.wayble.server.logging.repository.UserActionLogRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserActionLogService {
+    
+    private final UserActionLogRepository userActionLogRepository;
+    
+    @Async("loggingTaskExecutor")
+    public CompletableFuture<Void> logUserRegister(Long userId, String loginType, String userType) {
+        try {
+            HttpServletRequest request = getCurrentRequest();
+            
+            UserActionLog userActionLog = UserActionLog.builder()
+                    .userId(userId)
+                    .action(UserActionLog.ActionType.USER_REGISTER.name())
+                    .userAgent(request != null ? request.getHeader("User-Agent") : null)
+                    .timestamp(LocalDateTime.now())
+                    .loginType(loginType)
+                    .userType(userType)
+                    .build();
+                    
+            userActionLogRepository.save(userActionLog);
+            log.info("User register log saved: userId={}, loginType={}, userType={}", userId, loginType, userType);
+        } catch (Exception e) {
+            log.error("Failed to save user register log: userId={}", userId, e);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+    
+    
+    public long getTodayUserRegistrationCount() {
+        LocalDateTime startOfDay = LocalDateTime.now().toLocalDate().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        
+        return userActionLogRepository.countByActionAndTimestampBetween(
+                UserActionLog.ActionType.USER_REGISTER.name(), startOfDay, endOfDay);
+    }
+    
+    @Async("loggingTaskExecutor")
+    public CompletableFuture<Void> logTokenRefresh(Long userId, String userType) {
+        try {
+            HttpServletRequest request = getCurrentRequest();
+            
+            // 하루에 한 번만 로그 저장하도록 체크
+            LocalDateTime startOfDay = LocalDateTime.now().toLocalDate().atStartOfDay();
+            LocalDateTime endOfDay = startOfDay.plusDays(1);
+            
+            long existingCount = userActionLogRepository.countByUserIdAndActionAndTimestampBetween(
+                    userId, UserActionLog.ActionType.USER_TOKEN_REFRESH.name(), startOfDay, endOfDay);
+            
+            if (existingCount == 0) {
+                UserActionLog userActionLog = UserActionLog.builder()
+                        .userId(userId)
+                        .action(UserActionLog.ActionType.USER_TOKEN_REFRESH.name())
+                        .userAgent(request != null ? request.getHeader("User-Agent") : null)
+                        .timestamp(LocalDateTime.now())
+                        .loginType(null) // 토큰 갱신시에는 loginType 불필요
+                        .userType(userType)
+                        .build();
+                        
+                userActionLogRepository.save(userActionLog);
+                log.info("User token refresh log saved: userId={}, userType={}", userId, userType);
+            } else {
+                log.debug("Token refresh already logged today for userId: {}", userId);
+            }
+        } catch (Exception e) {
+            log.error("Failed to save user token refresh log: userId={}", userId, e);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+    
+    public long getTodayActiveUserCount() {
+        LocalDateTime startOfDay = LocalDateTime.now().toLocalDate().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        
+        return userActionLogRepository.countDistinctUserIdByActionAndTimestampBetween(
+                UserActionLog.ActionType.USER_TOKEN_REFRESH.name(), startOfDay, endOfDay);
+    }
+    
+    private HttpServletRequest getCurrentRequest() {
+        try {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            return attributes != null ? attributes.getRequest() : null;
+        } catch (Exception e) {
+            log.debug("Failed to get current request", e);
+            return null;
+        }
+    }
+    
+}

--- a/src/main/java/com/wayble/server/user/service/UserService.java
+++ b/src/main/java/com/wayble/server/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.wayble.server.user.service;
 
 import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.logging.service.UserActionLogService;
 import com.wayble.server.user.dto.UserRegisterRequestDto;
 import com.wayble.server.user.entity.User;
 import com.wayble.server.user.exception.UserErrorCase;
@@ -15,6 +16,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserActionLogService userActionLogService;
 
     // 회원가입
     public void signup(UserRegisterRequestDto req) {
@@ -26,7 +28,14 @@ public class UserService {
                 passwordEncoder.encode(req.password()),
                 req.loginType()
         );
-        userRepository.save(user);
+        User savedUser = userRepository.save(user);
+        
+        // 회원가입 로그 저장 (비동기)
+        userActionLogService.logUserRegister(
+                savedUser.getId(), 
+                req.loginType().name(), 
+                null
+        );
     }
 
     public void makeException() {

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -58,7 +58,7 @@
         </div>
 
         <!-- 통계 카드 -->
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
             <!-- 전체 사용자 수 -->
             <div class="bg-white overflow-hidden shadow rounded-lg">
                 <div class="p-5">
@@ -106,7 +106,7 @@
                 <div class="p-5">
                     <div class="flex items-center">
                         <div class="flex-shrink-0">
-                            <div class="h-8 w-8 bg-yellow-500 rounded-md flex items-center justify-center">
+                            <div class="h-8 w-8 bg-purple-500 rounded-md flex items-center justify-center">
                                 <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
                                 </svg>
@@ -115,12 +115,34 @@
                         <div class="ml-5 w-0 flex-1">
                             <dl>
                                 <dt class="text-sm font-medium text-gray-500 truncate">오늘 방문자</dt>
-                                <dd class="text-lg font-medium text-gray-900">892명</dd>
+                                <dd class="text-lg font-medium text-gray-900" th:text="${dailyStats.dailyActiveUserCount} + '명'">0명</dd>
                             </dl>
                         </div>
                     </div>
                 </div>
             </div>
+
+            <!-- 오늘 가입자 수 -->
+            <div class="bg-white overflow-hidden shadow rounded-lg">
+                <div class="p-5">
+                    <div class="flex items-center">
+                        <div class="flex-shrink-0">
+                            <div class="h-8 w-8 bg-orange-500 rounded-md flex items-center justify-center">
+                                <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="ml-5 w-0 flex-1">
+                            <dl>
+                                <dt class="text-sm font-medium text-gray-500 truncate">오늘 가입자</dt>
+                                <dd class="text-lg font-medium text-gray-900" th:text="${dailyStats.dailyRegistrationCount} + '명'">0명</dd>
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
         </div>
 
         <!-- 관리 메뉴 -->

--- a/src/main/resources/templates/admin/user/user-detail.html
+++ b/src/main/resources/templates/admin/user/user-detail.html
@@ -67,12 +67,12 @@
                 </div>
                 <div class="flex items-center space-x-3">
                     <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium"
-                          th:classappend="${user.userType.name() == 'GENERAL'} ? 'bg-blue-100 text-blue-800' : (${user.userType.name() == 'DISABLED'} ? 'bg-purple-100 text-purple-800' : 'bg-green-100 text-green-800')"
-                          th:text="${user.userType.name()}">
+                          th:classappend="${user.userType != null and user.userType.name() == 'GENERAL'} ? 'bg-blue-100 text-blue-800' : (${user.userType != null and user.userType.name() == 'DISABLED'} ? 'bg-purple-100 text-purple-800' : 'bg-gray-100 text-gray-800')"
+                          th:text="${user.userType != null ? user.userType.name() : '미설정'}">
                     </span>
                     <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium"
-                          th:classappend="${user.loginType.name() == 'WAYBLE'} ? 'bg-gray-100 text-gray-800' : 'bg-yellow-100 text-yellow-800'"
-                          th:text="${user.loginType.name()}">
+                          th:classappend="${user.loginType != null and user.loginType.name() == 'WAYBLE'} ? 'bg-gray-100 text-gray-800' : 'bg-yellow-100 text-yellow-800'"
+                          th:text="${user.loginType != null ? user.loginType.name() : '미설정'}">
                     </span>
                 </div>
             </div>
@@ -113,11 +113,11 @@
                             </div>
                             <div>
                                 <dt class="text-sm font-medium text-gray-500">로그인 타입</dt>
-                                <dd class="mt-1 text-sm text-gray-900" th:text="${user.loginType.name()}"></dd>
+                                <dd class="mt-1 text-sm text-gray-900" th:text="${user.loginType != null ? user.loginType.name() : '미설정'}"></dd>
                             </div>
                             <div>
                                 <dt class="text-sm font-medium text-gray-500">사용자 타입</dt>
-                                <dd class="mt-1 text-sm text-gray-900" th:text="${user.userType.name()}"></dd>
+                                <dd class="mt-1 text-sm text-gray-900" th:text="${user.userType != null ? user.userType.name() : '미설정'}"></dd>
                             </div>
                             <div class="sm:col-span-2">
                                 <dt class="text-sm font-medium text-gray-500">프로필 이미지</dt>

--- a/src/main/resources/templates/admin/user/users.html
+++ b/src/main/resources/templates/admin/user/users.html
@@ -99,12 +99,12 @@
                                 <div class="flex items-center space-x-3 mb-2">
                                     <h3 class="text-lg font-medium text-gray-900" th:text="${user.nickname ?: '닉네임 없음'}"></h3>
                                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
-                                          th:classappend="${user.userType.name() == 'GENERAL'} ? 'bg-blue-100 text-blue-800' : (${user.userType.name() == 'DISABLED'} ? 'bg-purple-100 text-purple-800' : 'bg-green-100 text-green-800')"
-                                          th:text="${user.userType.name()}">
+                                          th:classappend="${user.userType != null and user.userType.name() == 'GENERAL'} ? 'bg-blue-100 text-blue-800' : (${user.userType != null and user.userType.name() == 'DISABLED'} ? 'bg-purple-100 text-purple-800' : 'bg-gray-100 text-gray-800')"
+                                          th:text="${user.userType != null ? user.userType.name() : '미설정'}">
                                     </span>
                                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
-                                          th:classappend="${user.loginType.name() == 'WAYBLE'} ? 'bg-gray-100 text-gray-800' : 'bg-yellow-100 text-yellow-800'"
-                                          th:text="${user.loginType.name()}">
+                                          th:classappend="${user.loginType != null and user.loginType.name() == 'WAYBLE'} ? 'bg-gray-100 text-gray-800' : 'bg-yellow-100 text-yellow-800'"
+                                          th:text="${user.loginType != null ? user.loginType.name() : '미설정'}">
                                     </span>
                                 </div>
                                 
@@ -128,7 +128,7 @@
                                             <svg class="h-4 w-4 mr-1 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
                                             </svg>
-                                            <span th:text="${user.gender.name()}"></span>
+                                            <span th:text="${user.gender != null ? user.gender.name() : '미설정'}"></span>
                                         </span>
                                     </div>
                                 </div>


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #105 

## 📝 작업 내용

- 관리자 페이지에 당일 방문자 수, 가입자 수 항목 추가
- 관리자 페이지에 유저 목록이 조회되지 않던 버그 수정

### 스크린샷 (선택)

<img width="1274" height="773" alt="image" src="https://github.com/user-attachments/assets/97b5e83c-17d9-4e92-ae5c-fd26e03aed3a" />
