### PR TITLE
[feat] 가게가 웨이블존인지 여부를 판단하는 기능 구현

### DIFF
--- a/src/main/java/com/wayble/server/explore/controller/WaybleZoneSearchController.java
+++ b/src/main/java/com/wayble/server/explore/controller/WaybleZoneSearchController.java
@@ -67,6 +67,14 @@ public class WaybleZoneSearchController {
         ));
     }
 
+    @GetMapping("/validate")
+    public CommonResponse<WaybleZoneSearchResponseDto> findIsValidWaybleZone(
+            @Valid @ModelAttribute WaybleZoneSearchConditionDto conditionDto
+    )
+    {
+        return CommonResponse.success(waybleZoneSearchService.isValidWaybleZone(conditionDto));
+    }
+
     @PostMapping("")
     public CommonResponse<String> registerDocumentFromDto(@RequestBody WaybleZoneRegisterDto registerDto) {
         waybleZoneDocumentService.saveDocumentFromDto(registerDto);

--- a/src/main/java/com/wayble/server/explore/dto/search/request/WaybleZoneSearchConditionDto.java
+++ b/src/main/java/com/wayble/server/explore/dto/search/request/WaybleZoneSearchConditionDto.java
@@ -19,7 +19,6 @@ public record WaybleZoneSearchConditionDto(
         @NotNull(message = "경도 입력은 필수입니다.")
         Double longitude,
 
-        @DecimalMin(value = "0.1", message = "검색 반경은 100미터 이상이어야 합니다.")
         Double radiusKm,
 
         @Size(min = 2, message = "zoneName은 최소 2글자 이상이어야 합니다.")

--- a/src/main/java/com/wayble/server/explore/service/WaybleZoneSearchService.java
+++ b/src/main/java/com/wayble/server/explore/service/WaybleZoneSearchService.java
@@ -42,4 +42,8 @@ public class WaybleZoneSearchService {
 
         return waybleZoneRepository.findTop3likesWaybleZonesByDistrict(district);
     }
+
+    public WaybleZoneSearchResponseDto isValidWaybleZone(WaybleZoneSearchConditionDto condition) {
+        return waybleZoneQuerySearchRepository.findSimilarWaybleZone(condition);
+    }
 }


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #135 

## 📝 작업 내용

- 첨부한 사진처럼 지도에서 가게를 선택했을 때 웨이블존이면 뱃지를 추가해야 하기에, 이름과 위도 경도를 바탕으로 웨이블존이 맞는지 검증하는 로직을 구현했습니다.
- 이름과 위치가 완전히 일치하지 않을 수 있기에, 필터링을 다음과 같이 설정했습니다.
  - 전달받은 좌표에서 30m 이내면 통과
  - 공백 여부 고려, 약간의 오타 허용

### 스크린샷 (선택)
<img width="643" height="651" alt="image" src="https://github.com/user-attachments/assets/6372681c-0ef6-4779-aee9-8f7838de1344" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 신규 GET /validate 엔드포인트: 좌표와 영역명(부분/오타 허용)으로 주변 Wayble Zone을 검증하고 가장 가까운 결과와 거리(km)를 반환.
  * 검색 반경 최소 제한을 제거해 더 유연한 검증 입력을 지원.
  * 이름 유사도와 거리 기반 매칭 정밀도를 개선.

* Tests
  * /validate 엔드포인트 통합 테스트 추가: 응답 구조, 좌표 거리(≤30m) 및 이름 유사도 검증.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->