### PR TITLE
[refactor] 웨이블존 상세 조회에 위도,경도 추가 + 토큰 관련 리팩토링 + 웨이블존 목록 조회, 리뷰 작성 테스트 코드 작성 

### DIFF
--- a/src/main/java/com/wayble/server/auth/resolver/CurrentUser.java
+++ b/src/main/java/com/wayble/server/auth/resolver/CurrentUser.java
@@ -1,0 +1,8 @@
+package com.wayble.server.auth.resolver;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentUser {}

--- a/src/main/java/com/wayble/server/auth/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/wayble/server/auth/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,45 @@
+package com.wayble.server.auth.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mav,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) {
+            throw new IllegalStateException("인증 정보가 없습니다.");
+        }
+
+        Object principal = auth.getPrincipal();
+        if (principal instanceof Long l) return l;
+        if (principal instanceof Integer i) return i.longValue();
+        if (principal instanceof String s) {
+            try {
+                return Long.parseLong(s);
+            } catch (NumberFormatException ignored) {}
+        }
+        try {
+            return Long.parseLong(auth.getName());
+        } catch (Exception e) {
+            throw new IllegalStateException("userId를 추출할 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/wayble/server/common/config/WebMvcConfig.java
+++ b/src/main/java/com/wayble/server/common/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.wayble.server.common.config;
+
+import com.wayble.server.auth.resolver.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/wayble/server/review/controller/ReviewController.java
+++ b/src/main/java/com/wayble/server/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.wayble.server.review.controller;
 
+import com.wayble.server.auth.resolver.CurrentUser;
 import com.wayble.server.common.response.CommonResponse;
 import com.wayble.server.review.dto.ReviewRegisterDto;
 import com.wayble.server.review.dto.ReviewResponseDto;
@@ -11,8 +12,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -38,9 +37,9 @@ public class ReviewController {
     })
     public CommonResponse<String> registerReview(
             @PathVariable Long waybleZoneId,
+            @CurrentUser Long userId,
             @RequestBody @Valid ReviewRegisterDto dto
     ) {
-        Long userId = extractUserId(); // 토큰에서 유저 ID 추출
         reviewService.registerReview(waybleZoneId, userId, dto);
         return CommonResponse.success("리뷰가 등록되었습니다.");
     }
@@ -56,27 +55,5 @@ public class ReviewController {
             @RequestParam(defaultValue = "latest") String sort
     ) {
         return CommonResponse.success(reviewService.getReviews(waybleZoneId, sort));
-    }
-
-    private Long extractUserId() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null) { throw new IllegalStateException("인증 정보가 없습니다."); }
-
-        Object p = auth.getPrincipal();
-        if (p instanceof Long l) { return l; }
-        if (p instanceof Integer i) { return i.longValue(); }
-        if (p instanceof String s) {
-            try {
-                return Long.parseLong(s);
-            } catch (NumberFormatException e) {
-                throw new IllegalStateException("principal에서 userId 파싱 실패");
-            }
-        }
-        try {
-            return Long.parseLong(auth.getName());
-        }
-        catch (Exception e) {
-            throw new IllegalStateException("인증 정보에서 userId를 추출할 수 없습니다.");
-        }
     }
 }

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -1,6 +1,7 @@
 package com.wayble.server.user.controller;
 
 
+import com.wayble.server.auth.resolver.CurrentUser;
 import com.wayble.server.common.response.CommonResponse;
 import com.wayble.server.user.dto.UserPlaceRemoveRequestDto;
 import com.wayble.server.user.dto.UserPlaceRequestDto;
@@ -13,8 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -35,9 +34,9 @@ public class UserPlaceController {
             @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
     public CommonResponse<String> saveUserPlace(
+            @CurrentUser Long userId,
             @RequestBody @Valid UserPlaceRequestDto request
     ) {
-        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         userPlaceService.saveUserPlace(userId, request); // userId 파라미터로 넘김
         return CommonResponse.success("장소가 저장되었습니다.");
     }
@@ -50,9 +49,9 @@ public class UserPlaceController {
             @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
     public CommonResponse<List<UserPlaceSummaryDto>> getMyPlaceSummaries(
+            @CurrentUser Long userId,
             @RequestParam(name = "sort", defaultValue = "latest") String sort
     ) {
-        Long userId = extractUserId();
         List<UserPlaceSummaryDto> summaries = userPlaceService.getMyPlaceSummaries(userId, sort);
         return CommonResponse.success(summaries);
     }
@@ -67,11 +66,11 @@ public class UserPlaceController {
             @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
     public CommonResponse<Page<WaybleZoneListResponseDto>> getZonesInPlace(
+            @CurrentUser Long userId,
             @RequestParam Long placeId,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "20") Integer size
     ) {
-        Long userId = extractUserId();
         Page<WaybleZoneListResponseDto> zones = userPlaceService.getZonesInPlace(userId, placeId, page, size);
         return CommonResponse.success(zones);
     }
@@ -86,37 +85,11 @@ public class UserPlaceController {
             @ApiResponse(responseCode = "404", description = "장소 또는 매핑 정보를 찾을 수 없음"),
             @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
-    public CommonResponse<String> removeZoneFromPlace(@RequestBody @Valid UserPlaceRemoveRequestDto request) {
-        Long userId = extractUserId();
+    public CommonResponse<String> removeZoneFromPlace(
+            @CurrentUser Long userId,
+            @RequestBody @Valid UserPlaceRemoveRequestDto request
+    ) {
         userPlaceService.removeZoneFromPlace(userId, request.placeId(), request.waybleZoneId());
         return CommonResponse.success("제거되었습니다.");
-    }
-
-
-    // SecurityContext에서 userId 추출하는 로직
-    private Long extractUserId() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null) {
-            throw new IllegalStateException("인증 정보가 없습니다.");
-        }
-
-        Object p = auth.getPrincipal();
-
-        if (p instanceof Long l) { return l; }
-        if (p instanceof Integer i) { return i.longValue(); }
-        if (p instanceof String s) {
-            try {
-                return Long.parseLong(s);
-            } catch (NumberFormatException e) {
-                // 숫자 변환 실패 시 출력
-                System.err.println("Principal 문자열을 Long으로 변환할 수 없습니다: " + s);
-            }
-        }
-
-        try {
-            return Long.parseLong(auth.getName());
-        } catch (Exception e) {
-            throw new IllegalStateException("인증 정보에서 userId를 추출할 수 없습니다. Principal=" + p, e);
-        }
     }
 }

--- a/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneDetailResponseDto.java
+++ b/src/main/java/com/wayble/server/wayblezone/dto/WaybleZoneDetailResponseDto.java
@@ -18,7 +18,9 @@ public record WaybleZoneDetailResponseDto(
         String imageUrl,
         FacilityDto facilities,
         Map<String, BusinessHourDto> businessHours,
-        List<String> photos
+        List<String> photos,
+        Double latitude,
+        Double longitude
 ) {
     @Builder
     public record BusinessHourDto(

--- a/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
+++ b/src/main/java/com/wayble/server/wayblezone/service/WaybleZoneService.java
@@ -83,6 +83,9 @@ public class WaybleZoneService {
                     .build());
         }
 
+        Double lat = zone.getAddress() != null ? zone.getAddress().getLatitude() : null;
+        Double lon = zone.getAddress() != null ? zone.getAddress().getLongitude() : null;
+
         return WaybleZoneDetailResponseDto.builder()
                 .waybleZoneId(zone.getId())
                 .name(zone.getZoneName())
@@ -102,6 +105,8 @@ public class WaybleZoneService {
                         .floorInfo(f.getFloorInfo())
                         .build())
                 .businessHours(businessHours)
+                .latitude(lat)
+                .longitude(lon)
                 .build();
     }
 

--- a/src/test/java/com/wayble/server/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/wayble/server/review/service/ReviewServiceTest.java
@@ -1,0 +1,106 @@
+package com.wayble.server.review.service;
+
+import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.review.dto.ReviewRegisterDto;
+import com.wayble.server.review.entity.Review;
+import com.wayble.server.review.entity.ReviewImage;
+import com.wayble.server.review.repository.ReviewImageRepository;
+import com.wayble.server.review.repository.ReviewRepository;
+import com.wayble.server.user.entity.User;
+import com.wayble.server.user.repository.UserRepository;
+import com.wayble.server.wayblezone.entity.WaybleZone;
+import com.wayble.server.wayblezone.repository.WaybleZoneRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ReviewServiceTest {
+
+    private final ReviewRepository reviewRepository = mock(ReviewRepository.class);
+    private final ReviewImageRepository reviewImageRepository = mock(ReviewImageRepository.class);
+    private final WaybleZoneRepository waybleZoneRepository = mock(WaybleZoneRepository.class);
+    private final UserRepository userRepository = mock(UserRepository.class);
+
+    private final ReviewService sut =
+            new ReviewService(reviewRepository, reviewImageRepository, waybleZoneRepository, userRepository);
+
+    @Test
+    @DisplayName("리뷰 등록 성공 - 평점 갱신, 카운트 증가, 이미지 저장")
+    void t1() {
+        Long zoneId = 10L;
+        Long userId = 5L;
+
+        WaybleZone zone = mock(WaybleZone.class);
+        when(waybleZoneRepository.findById(zoneId)).thenReturn(Optional.of(zone));
+        when(zone.getRating()).thenReturn(4.0);
+        when(zone.getReviewCount()).thenReturn(1L);
+
+        User user = mock(User.class);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        ReviewRegisterDto dto = new ReviewRegisterDto(
+                "뷰가 좋고 접근성이 좋아요",
+                5.0,
+                LocalDate.of(2025, 6, 30),
+                List.of("주차장 있음", "장애인 화장실 있음"),
+                List.of("https://image.url/review1.jpg")
+        );
+
+        doAnswer(invocation -> invocation.getArgument(0))
+                .when(reviewRepository).save(any(Review.class));
+
+        sut.registerReview(zoneId, userId, dto);
+
+
+        verify(reviewRepository, times(1)).save(any(Review.class));
+
+        ArgumentCaptor<Double> ratingCaptor = ArgumentCaptor.forClass(Double.class);
+        verify(zone, times(1)).updateRating(ratingCaptor.capture());
+
+        assertEquals(4.5, ratingCaptor.getValue(), 1e-6);
+
+        verify(zone, times(1)).addReviewCount(1L);
+        verify(reviewImageRepository, times(1)).save(any(ReviewImage.class));
+        verify(waybleZoneRepository, times(1)).save(zone);
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 웨이블존 없음")
+    void t2() {
+        Long zoneId = 99L;
+        Long userId = 1L;
+        when(waybleZoneRepository.findById(zoneId)).thenReturn(Optional.empty());
+
+        ReviewRegisterDto dto = new ReviewRegisterDto(
+                "좋아요", 4.0, LocalDate.now(), List.of("주차장"), List.of()
+        );
+
+        assertThrows(ApplicationException.class,
+                () -> sut.registerReview(zoneId, userId, dto));
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 유저 없음")
+    void t3() {
+        Long zoneId = 10L;
+        Long userId = 999L;
+
+        WaybleZone zone = mock(WaybleZone.class);
+        when(waybleZoneRepository.findById(zoneId)).thenReturn(Optional.of(zone));
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        ReviewRegisterDto dto = new ReviewRegisterDto(
+                "좋아요", 4.0, LocalDate.now(), List.of("주차장"), List.of()
+        );
+
+        assertThrows(ApplicationException.class,
+                () -> sut.registerReview(zoneId, userId, dto));
+    }
+}

--- a/src/test/java/com/wayble/server/wayblezone/controller/WaybleZoneControllerTest.java
+++ b/src/test/java/com/wayble/server/wayblezone/controller/WaybleZoneControllerTest.java
@@ -1,0 +1,94 @@
+package com.wayble.server.wayblezone.controller;
+
+import com.wayble.server.common.dto.FacilityDto;
+import com.wayble.server.common.response.CommonResponse;
+import com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto;
+import com.wayble.server.wayblezone.service.WaybleZoneService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+public class WaybleZoneControllerTest {
+    @Mock
+    private WaybleZoneService waybleZoneService;
+
+    @InjectMocks
+    private WaybleZoneController waybleZoneController;
+
+    @Test
+    @DisplayName("웨이블존 목록 조회 - 성공")
+    void t1() {
+        FacilityDto facilities = FacilityDto.builder()
+                .hasSlope(true)
+                .hasNoDoorStep(true)
+                .hasElevator(false)
+                .hasTableSeat(true)
+                .hasDisabledToilet(false)
+                .floorInfo("1층")
+                .build();
+
+        WaybleZoneListResponseDto item1 = WaybleZoneListResponseDto.builder()
+                .waybleZoneId(1L)
+                .name("스타벅스 강남점")
+                .category("카페")
+                .address("서울 강남구 강남대로 446 (역삼동)")
+                .rating(4.5)
+                .reviewCount(23L)
+                .imageUrl("https://image.url/wayble1.jpg")
+                .contactNumber("02-558-2161")
+                .facilities(facilities)
+                .build();
+
+        WaybleZoneListResponseDto item2 = WaybleZoneListResponseDto.builder()
+                .waybleZoneId(2L)
+                .name("메가엠지씨커피 강남중앙점")
+                .category("카페")
+                .address("서울특별시 서초구 서초대로77길 35, 1층 102호 (서초동)")
+                .rating(4.2)
+                .reviewCount(520L)
+                .imageUrl("https://image.url/wayble1.jpg")
+                .contactNumber("02-533-0656")
+                .facilities(facilities)
+                .build();
+
+        when(waybleZoneService.getWaybleZones("서초구", "카페"))
+                .thenReturn(List.of(item1, item2));
+
+        CommonResponse<List<WaybleZoneListResponseDto>> response = waybleZoneController.getWaybleZoneList("서초구", "카페");
+
+        assertNotNull(response);
+        assertNotNull(response.getData());
+        assertEquals(2, response.getData().size());
+
+        WaybleZoneListResponseDto first = response.getData().get(0);
+        assertEquals(1L, first.waybleZoneId());
+        assertEquals("스타벅스 강남점", first.name());
+        assertEquals("카페", first.category());
+        assertTrue(first.address().contains("강남대로"));
+        assertEquals(4.5, first.rating(), 1e-6);
+        assertEquals(23L, first.reviewCount());
+        assertEquals("https://image.url/wayble1.jpg", first.imageUrl());
+        assertEquals("02-558-2161", first.contactNumber());
+        assertNotNull(first.facilities());
+        assertTrue(first.facilities().hasSlope());
+        assertTrue(first.facilities().hasNoDoorStep());
+        assertFalse(first.facilities().hasElevator());
+        assertTrue(first.facilities().hasTableSeat());
+        assertFalse(first.facilities().hasDisabledToilet());
+        assertEquals("1층", first.facilities().floorInfo());
+
+        WaybleZoneListResponseDto second = response.getData().get(1);
+        assertEquals(2L, second.waybleZoneId());
+        assertEquals(520L, second.reviewCount());
+    }
+}


### PR DESCRIPTION
## ✔️ 연관 이슈

#118 

## 📝 작업 내용

**1. 웨이블존 목록 조회 관련 테스트 코드 작성**
- 목록 조회 API의 정상 동작 및 필수 파라미터 누락 시 400 응답 관련 테스트 코드 작성 

**2. 웨이블존 상세 조회 Dto 리팩토링**
- WaybleZoneDetailResponseDto에 위도,경도 필드 추가

**3. 웨이블존 상세 조회 Service 리팩토링**
- WaybleZoneService 상세 조회 로직에서 위도/경도 정보 반환하도록 수정

**4. 리뷰 등록 관련 테스트 코드 작성**
- 성공 케이스 (평점 갱신, 리뷰 카운트 증가, 이미지 저장)
- 실패 케이스: 웨이블존 없음, 유저 없음


**5. 공통 리졸버 및 Config 추가**
- @CurrentUser 어노테이션 리졸버 추가 
- WebMvcConfig를 통해 리졸버 등록

## 스크린샷 (선택)
> X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 웨이블존 상세 응답에 위도·경도 정보가 추가되어 지도 및 위치 기반 기능 연동이 용이해졌습니다.
- 리팩터링
  - 인증된 사용자 식별자 주입 방식을 개선하여 리뷰 등록 및 내 장소 관련 엔드포인트의 인증 연동을 단순화했습니다.
- 테스트
  - 리뷰 등록 서비스와 웨이블존 목록 조회 컨트롤러에 대한 단위 테스트를 추가해 품질과 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->