### PR TITLE
[refactor] 리졸버 로직 개선, swagger에서 userId 필수 파라미터 입력인곳 제거 

### DIFF
--- a/src/main/java/com/wayble/server/auth/exception/AuthErrorCase.java
+++ b/src/main/java/com/wayble/server/auth/exception/AuthErrorCase.java
@@ -1,0 +1,15 @@
+package com.wayble.server.auth.exception;
+
+import com.wayble.server.common.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCase implements ErrorCase {
+    UNAUTHORIZED(401, 1001, "인증 정보가 없거나 userId를 추출할 수 없습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String message;
+}

--- a/src/main/java/com/wayble/server/auth/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/wayble/server/auth/resolver/CurrentUserArgumentResolver.java
@@ -1,6 +1,8 @@
 package com.wayble.server.auth.resolver;
 
+import com.wayble.server.auth.exception.AuthErrorCase;
 import com.wayble.server.common.config.security.jwt.JwtTokenProvider;
+import com.wayble.server.common.exception.ApplicationException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -54,6 +56,6 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
             if (userId != null) { return userId; }
         }
 
-        throw new IllegalStateException("인증 정보가 없거나 userId를 추출할 수 없습니다.");
+        throw new ApplicationException(AuthErrorCase.UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/wayble/server/auth/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/wayble/server/auth/resolver/CurrentUserArgumentResolver.java
@@ -1,16 +1,23 @@
 package com.wayble.server.auth.resolver;
 
+import com.wayble.server.common.config.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
+@RequiredArgsConstructor
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -19,27 +26,34 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter,
-                                  ModelAndViewContainer mav,
-                                  NativeWebRequest webRequest,
-                                  WebDataBinderFactory binderFactory) {
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mav,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null) {
-            throw new IllegalStateException("인증 정보가 없습니다.");
+        if (auth != null) {
+            Object principal = auth.getPrincipal();
+            if (principal instanceof Long l) { return l; }
+            if (principal instanceof Integer i) { return i.longValue(); }
+            if (principal instanceof String s && s.chars().allMatch(Character::isDigit)) {
+                return Long.parseLong(s);
+            }
+            String name = auth.getName();
+            if (name != null && name.chars().allMatch(Character::isDigit)) {
+                return Long.parseLong(name);
+            }
         }
 
-        Object principal = auth.getPrincipal();
-        if (principal instanceof Long l) return l;
-        if (principal instanceof Integer i) return i.longValue();
-        if (principal instanceof String s) {
-            try {
-                return Long.parseLong(s);
-            } catch (NumberFormatException ignored) {}
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String authz = request != null ? request.getHeader("Authorization") : null;
+        if (StringUtils.hasText(authz) && authz.startsWith("Bearer ")) {
+            String token = authz.substring(7);
+            Long userId = jwtTokenProvider.getUserId(token);
+            if (userId != null) { return userId; }
         }
-        try {
-            return Long.parseLong(auth.getName());
-        } catch (Exception e) {
-            throw new IllegalStateException("userId를 추출할 수 없습니다.", e);
-        }
+
+        throw new IllegalStateException("인증 정보가 없거나 userId를 추출할 수 없습니다.");
     }
 }

--- a/src/main/java/com/wayble/server/auth/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/wayble/server/auth/resolver/CurrentUserArgumentResolver.java
@@ -52,8 +52,12 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
         String authz = request != null ? request.getHeader("Authorization") : null;
         if (StringUtils.hasText(authz) && authz.startsWith("Bearer ")) {
             String token = authz.substring(7);
-            Long userId = jwtTokenProvider.getUserId(token);
-            if (userId != null) { return userId; }
+            try {
+                Long userId = jwtTokenProvider.getUserId(token);
+                if (userId != null) { return userId; }
+            } catch (IllegalArgumentException e) {
+                throw new ApplicationException(AuthErrorCase.UNAUTHORIZED);
+            }
         }
 
         throw new ApplicationException(AuthErrorCase.UNAUTHORIZED);

--- a/src/main/java/com/wayble/server/review/controller/ReviewController.java
+++ b/src/main/java/com/wayble/server/review/controller/ReviewController.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.Parameter;
 
 import java.util.List;
 
@@ -37,7 +37,7 @@ public class ReviewController {
     })
     public CommonResponse<String> registerReview(
             @PathVariable Long waybleZoneId,
-            @CurrentUser Long userId,
+            @Parameter(hidden = true) @CurrentUser Long userId,
             @RequestBody @Valid ReviewRegisterDto dto
     ) {
         reviewService.registerReview(waybleZoneId, userId, dto);

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -9,6 +9,7 @@ import com.wayble.server.user.dto.UserPlaceSummaryDto;
 import com.wayble.server.user.service.UserPlaceService;
 import com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
@@ -34,7 +35,7 @@ public class UserPlaceController {
             @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
     public CommonResponse<String> saveUserPlace(
-            @CurrentUser Long userId,
+            @Parameter(hidden = true) @CurrentUser Long userId,
             @RequestBody @Valid UserPlaceRequestDto request
     ) {
         userPlaceService.saveUserPlace(userId, request); // userId 파라미터로 넘김
@@ -49,7 +50,7 @@ public class UserPlaceController {
             @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
     public CommonResponse<List<UserPlaceSummaryDto>> getMyPlaceSummaries(
-            @CurrentUser Long userId,
+            @Parameter(hidden = true) @CurrentUser Long userId,
             @RequestParam(name = "sort", defaultValue = "latest") String sort
     ) {
         List<UserPlaceSummaryDto> summaries = userPlaceService.getMyPlaceSummaries(userId, sort);
@@ -66,7 +67,7 @@ public class UserPlaceController {
             @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
     public CommonResponse<Page<WaybleZoneListResponseDto>> getZonesInPlace(
-            @CurrentUser Long userId,
+            @Parameter(hidden = true) @CurrentUser Long userId,
             @RequestParam Long placeId,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "20") Integer size
@@ -86,7 +87,7 @@ public class UserPlaceController {
             @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
     })
     public CommonResponse<String> removeZoneFromPlace(
-            @CurrentUser Long userId,
+            @Parameter(hidden = true) @CurrentUser Long userId,
             @RequestBody @Valid UserPlaceRemoveRequestDto request
     ) {
         userPlaceService.removeZoneFromPlace(userId, request.placeId(), request.waybleZoneId());

--- a/src/test/java/com/wayble/server/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/wayble/server/review/service/ReviewServiceTest.java
@@ -66,7 +66,7 @@ class ReviewServiceTest {
 
         assertEquals(4.5, ratingCaptor.getValue(), 1e-6);
 
-        verify(zone, times(1)).addReviewCount(1L);
+        verify(zone, times(1)).addReviewCount(1);
         verify(reviewImageRepository, times(1)).save(any(ReviewImage.class));
         verify(waybleZoneRepository, times(1)).save(zone);
     }


### PR DESCRIPTION
## ✔️ 연관 이슈

-  #79 

## 📝 작업 내용

1. 리졸버 로직 개선
- JwtTokenProvider 의존성 주입 추가
- principal 타입별 파싱
- 토큰 기반 파싱 추가

2. Swagger에서 userId를 필수 파라미터로 입력해야하는곳에 대해서 문서쪽에서 필수 파라미터 userId 제거
> 이유: 회원가입 및 로그인을 완료해도 본인의 userId를 알려면 직접 admin 페이지에 들어가서 확인해야하는 불편함이 있어서 userId를 입력하지 않아도 api 테스트 가능하도록 설정 

### 스크린샷 (선택)
> X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 다양한 인증 전달 방식(세션/인증 객체 및 헤더의 Bearer 토큰 포함)에서 사용자 식별 안정성을 개선했습니다. 식별 실패 시 명확한 인증 오류(권한 없음)로 처리됩니다.
- 문서
  - API 문서에서 내부 주입되는 사용자 ID 파라미터를 숨겨 스펙을 간결하게 했습니다(리뷰 등록 및 내 장소/존 관련 엔드포인트).
- 테스트
  - 리뷰 서비스 관련 테스트를 최신 동작에 맞게 보정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->