### PR TITLE
[fix] 유저 웨이블존 저장 및 조회 관련 API 수정 

### DIFF
--- a/src/main/java/com/wayble/server/auth/exception/AuthErrorCase.java
+++ b/src/main/java/com/wayble/server/auth/exception/AuthErrorCase.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCase implements ErrorCase {
-    UNAUTHORIZED(401, 1001, "인증 정보가 없거나 userId를 추출할 수 없습니다.");
+    UNAUTHORIZED(401, 7001, "인증 정보가 없거나 userId를 추출할 수 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -3,9 +3,7 @@ package com.wayble.server.user.controller;
 
 import com.wayble.server.auth.resolver.CurrentUser;
 import com.wayble.server.common.response.CommonResponse;
-import com.wayble.server.user.dto.UserPlaceRemoveRequestDto;
-import com.wayble.server.user.dto.UserPlaceRequestDto;
-import com.wayble.server.user.dto.UserPlaceSummaryDto;
+import com.wayble.server.user.dto.*;
 import com.wayble.server.user.service.UserPlaceService;
 import com.wayble.server.wayblezone.dto.WaybleZoneListResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,19 +25,25 @@ public class UserPlaceController {
     private final UserPlaceService userPlaceService;
 
     @PostMapping
-    @Operation(summary = "유저 장소 저장", description = "유저가 웨이블존을 장소로 저장합니다.")
+    @Operation(summary = "웨이블존 저장할 리스트 생성",
+            description = "제목과 색상을 받아 웨이블존을 저장할 리스트를 생성합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "장소 저장 성공"),
-            @ApiResponse(responseCode = "400", description = "이미 저장한 장소입니다."),
-            @ApiResponse(responseCode = "404", description = "해당 유저 또는 웨이블존이 존재하지 않음"),
-            @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
+            @ApiResponse(responseCode = "200", description = "리스트 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "동일한 리스트명이 이미 존재")
     })
-    public CommonResponse<String> saveUserPlace(
+    public CommonResponse<UserPlaceCreateResponseDto> createPlaceList(
             @Parameter(hidden = true) @CurrentUser Long userId,
-            @RequestBody @Valid UserPlaceRequestDto request
+            @RequestBody @Valid UserPlaceCreateRequestDto request
     ) {
-        userPlaceService.saveUserPlace(userId, request); // userId 파라미터로 넘김
-        return CommonResponse.success("장소가 저장되었습니다.");
+        Long placeId = userPlaceService.createPlaceList(userId, request);
+        return CommonResponse.success(
+                UserPlaceCreateResponseDto.builder()
+                        .placeId(placeId)
+                        .title(request.title())
+                        .color((request.color() == null || request.color().isBlank()) ? "GRAY" : request.color())
+                        .message("리스트가 생성되었습니다.")
+                        .build()
+        );
     }
 
     @GetMapping
@@ -55,25 +59,6 @@ public class UserPlaceController {
     ) {
         List<UserPlaceSummaryDto> summaries = userPlaceService.getMyPlaceSummaries(userId, sort);
         return CommonResponse.success(summaries);
-    }
-
-
-    @GetMapping("/zones")
-    @Operation(summary = "특정 장소 내 웨이블존 목록 조회(페이징)",
-            description = "placeId로 해당 장소 내부의 웨이블존 카드 목록을 반환합니다. (page는 1부터 시작.)")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "유저/장소를 찾을 수 없음"),
-            @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
-    })
-    public CommonResponse<Page<WaybleZoneListResponseDto>> getZonesInPlace(
-            @Parameter(hidden = true) @CurrentUser Long userId,
-            @RequestParam Long placeId,
-            @RequestParam(defaultValue = "1") Integer page,
-            @RequestParam(defaultValue = "20") Integer size
-    ) {
-        Page<WaybleZoneListResponseDto> zones = userPlaceService.getZonesInPlace(userId, placeId, page, size);
-        return CommonResponse.success(zones);
     }
 
     @DeleteMapping
@@ -92,5 +77,38 @@ public class UserPlaceController {
     ) {
         userPlaceService.removeZoneFromPlace(userId, request.placeId(), request.waybleZoneId());
         return CommonResponse.success("제거되었습니다.");
+    }
+
+    @PostMapping("/zones")
+    @Operation(summary = "리스트에 웨이블존 추가",
+            description = "placeId와 waybleZoneId 배열을 받아 여러 웨이블존을 리스트에 추가합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "웨이블존 추가 성공"),
+            @ApiResponse(responseCode = "404", description = "유저/리스트/웨이블존을 찾을 수 없음")
+    })
+    public CommonResponse<String> addZonesToPlace(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @RequestBody @Valid UserPlaceAddZonesRequestDto request
+    ) {
+        userPlaceService.addZonesToPlace(userId, request.placeId(), request.waybleZoneIds());
+        return CommonResponse.success("리스트에 웨이블존이 추가되었습니다.");
+    }
+
+    @GetMapping("/zones")
+    @Operation(summary = "특정 장소 내 웨이블존 목록 조회(페이징)",
+            description = "placeId로 해당 장소 내부의 웨이블존 카드 목록을 반환합니다. (page는 1부터 시작.)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "유저/장소를 찾을 수 없음"),
+            @ApiResponse(responseCode = "403", description = "권한이 없습니다.")
+    })
+    public CommonResponse<Page<WaybleZoneListResponseDto>> getZonesInPlace(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @RequestParam Long placeId,
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        Page<WaybleZoneListResponseDto> zones = userPlaceService.getZonesInPlace(userId, placeId, page, size);
+        return CommonResponse.success(zones);
     }
 }

--- a/src/main/java/com/wayble/server/user/dto/UserPlaceAddZonesRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserPlaceAddZonesRequestDto.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public record UserPlaceAddZonesRequestDto(
         @NotNull Long placeId,
-        @NotEmpty List<Long> waybleZoneId
+        @NotEmpty List<Long> waybleZoneIds
 ) {}

--- a/src/main/java/com/wayble/server/user/dto/UserPlaceAddZonesRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserPlaceAddZonesRequestDto.java
@@ -1,0 +1,10 @@
+package com.wayble.server.user.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record UserPlaceAddZonesRequestDto(
+        @NotNull Long placeId,
+        @NotEmpty List<Long> waybleZoneId
+) {}

--- a/src/main/java/com/wayble/server/user/dto/UserPlaceCreateRequestDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserPlaceCreateRequestDto.java
@@ -1,0 +1,8 @@
+package com.wayble.server.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserPlaceCreateRequestDto(
+        @NotBlank(message = "제목은 필수입니다.") String title,
+        String color
+) {}

--- a/src/main/java/com/wayble/server/user/dto/UserPlaceCreateResponseDto.java
+++ b/src/main/java/com/wayble/server/user/dto/UserPlaceCreateResponseDto.java
@@ -1,0 +1,11 @@
+package com.wayble.server.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserPlaceCreateResponseDto(
+        Long placeId,
+        String title,
+        String color,
+        String message
+) {}

--- a/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/wayble/server/user/exception/UserErrorCase.java
@@ -22,7 +22,8 @@ public enum UserErrorCase implements ErrorCase {
     NICKNAME_REQUIRED(400, 1012,"nickname 파라미터는 필수입니다."),
     NICKNAME_DUPLICATED(409,1013, "이미 사용 중인 닉네임입니다."),
     PLACE_NOT_FOUND(404, 1014, "저장된 장소를 찾을 수 없습니다."),
-    PLACE_MAPPING_NOT_FOUND(404, 1015, "해당 장소에 해당 웨이블존이 없습니다.");
+    PLACE_MAPPING_NOT_FOUND(404, 1015, "해당 장소에 해당 웨이블존이 없습니다."),
+    PLACE_TITLE_DUPLICATED(400, 1016, "동일한 이름의 리스트가 이미 있습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/wayble/server/user/service/UserPlaceService.java
+++ b/src/main/java/com/wayble/server/user/service/UserPlaceService.java
@@ -2,6 +2,7 @@ package com.wayble.server.user.service;
 
 
 import com.wayble.server.common.exception.ApplicationException;
+import com.wayble.server.user.dto.UserPlaceCreateRequestDto;
 import com.wayble.server.user.dto.UserPlaceRequestDto;
 import com.wayble.server.user.dto.UserPlaceSummaryDto;
 import com.wayble.server.user.entity.User;
@@ -22,7 +23,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -34,42 +37,56 @@ public class UserPlaceService {
     private final UserPlaceWaybleZoneMappingRepository mappingRepository;
 
     @Transactional
-    public void saveUserPlace(Long userId, UserPlaceRequestDto request) {
-        // 유저 존재 확인
+    public Long createPlaceList(Long userId, UserPlaceCreateRequestDto request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
 
-        // 웨이블존 존재 확인
-        WaybleZone waybleZone = waybleZoneRepository.findById(request.waybleZoneId())
-                .orElseThrow(() -> new ApplicationException(UserErrorCase.WAYBLE_ZONE_NOT_FOUND));
-
-        // 중복 저장 확인
-        boolean duplicated = mappingRepository.existsByUserPlace_User_IdAndWaybleZone_Id(userId, request.waybleZoneId());
-        if (duplicated) {
-            throw new ApplicationException(UserErrorCase.PLACE_ALREADY_SAVED);
-        }
+        userPlaceRepository.findByUser_IdAndTitle(userId, request.title())
+                .ifPresent(p -> { throw new ApplicationException(UserErrorCase.PLACE_TITLE_DUPLICATED); });
 
         String color = (request.color() == null || request.color().isBlank()) ? "GRAY" : request.color();
-        UserPlace userPlace = userPlaceRepository.findByUser_IdAndTitle(userId, request.title())
-                .orElseGet(() -> userPlaceRepository.save(
-                        UserPlace.builder()
-                                .title(request.title())
-                                .color(color)
-                                .user(user)
-                                .build()
-                ));
 
-        mappingRepository.save(UserPlaceWaybleZoneMapping.builder()
-                .userPlace(userPlace)
-                .waybleZone(waybleZone)
-                .build());
-
-        userPlace.increaseCount();
-        userPlaceRepository.save(userPlace);
-
-        waybleZone.addLikes(1);
-        waybleZoneRepository.save(waybleZone);
+        UserPlace saved = userPlaceRepository.save(
+                UserPlace.builder()
+                        .title(request.title())
+                        .color(color)
+                        .user(user)
+                        .savedCount(0)
+                        .build()
+        );
+        return saved.getId();
     }
+
+    @Transactional
+    public void addZonesToPlace(Long userId, Long placeId, List<Long> waybleZoneIds) {
+        UserPlace place = userPlaceRepository.findByIdAndUser_Id(placeId, userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.PLACE_NOT_FOUND));
+
+        Set<Long> uniqueIds = new LinkedHashSet<>(waybleZoneIds);
+
+        int added = 0;
+        for (Long zoneId : uniqueIds) {
+            WaybleZone zone = waybleZoneRepository.findById(zoneId)
+                    .orElseThrow(() -> new ApplicationException(UserErrorCase.WAYBLE_ZONE_NOT_FOUND));
+
+            boolean exists = mappingRepository.existsByUserPlace_IdAndWaybleZone_Id(placeId, zoneId);
+            if (exists) continue;
+
+            mappingRepository.save(UserPlaceWaybleZoneMapping.builder()
+                    .userPlace(place)
+                    .waybleZone(zone)
+                    .build());
+
+            place.increaseCount();
+            zone.addLikes(1);
+            waybleZoneRepository.save(zone);
+
+            added++;
+        }
+
+        if (added > 0) userPlaceRepository.save(place);
+    }
+
 
     @Transactional(readOnly = true)
     public List<UserPlaceSummaryDto> getMyPlaceSummaries(Long userId, String sort) {


### PR DESCRIPTION
## ✔️ 연관 이슈

-  #170 

## 📝 작업 내용

**1) 유저 장소 저장 API 이름, 역할 수정**

POST => /api/v1/users/places

의미: 웨이블존을 저장할 리스트 생성

(기존) 웨이블존을 즉시 저장 -> (변경) 웨이블존을 저장하기 위한 리스트만 생성 (여기서 웨이블존 저장 X)

**Request Body:**

```
{
  "title": "장애인 전용 카페",
  "color": "PINK"
}

```

**Response Body:**

```
{
  "data": {
    "placeId": 5,
    "title": "장애인 전용 카페",
    "color": "PINK",
    "message": "리스트가 생성되었습니다."
  }
}
```

**2) 리스트에 웨이블존 추가 API 구현**

POST => /api/v1/users/places/zones

의미: 기존에 만든 리스트에 웨이블존을 추가 (여러개 가능)

**Request Body:**

```
{
  "placeId": 5,
  "waybleZoneIds": [280, 281, 282]
}
```


**Response Body:**

```
{
  "message": "리스트에 웨이블존이 추가되었습니다."
}
```

중복 ID 제거 및 이미 담긴 웨이블존은 건너뛰고, 성공적으로 담긴 개수만큼 savedCount , likes 증가

**3) 특정 장소 리스트에 대하여 페이징 조회 테스트**
리스트에 웨이블존 여러개 저장하고 페이징 조회 해보면 각각 웨이블존에 대해서 여러개 조회 완료 


## 🖼️스크린샷 (선택)
### 웨이블존 저장할 리스트 생성 성공
<img width="1460" height="943" alt="리스트생성성공" src="https://github.com/user-attachments/assets/34820dc4-c1d9-44ff-af39-56666e56b6aa" />

### 리스트에 웨이블존 추가 성공
<img width="1457" height="947" alt="리스트에웨이블존추가성공" src="https://github.com/user-attachments/assets/18711384-0a96-448c-b803-42c6f4a61c15" />

### 특정 장소 리스트에 대하여 페이징 조회 성공
<img width="1456" height="939" alt="특정장소리스트에대해서페이징조회성공" src="https://github.com/user-attachments/assets/cad82ab8-c79c-4afb-96e8-9d508ae8580a" />

### 리스트에서 저장한 웨이블존 삭제 성공
<img width="1460" height="941" alt="리스트에서웨이블존제거성공" src="https://github.com/user-attachments/assets/7e4d3c95-f121-4ec8-a427-59a2ffdd8871" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 사용자 장소 리스트 생성 API 개선: 기본 색상 GRAY 적용, 생성 결과(아이디/제목/색상/메시지) 반환
  - 장소 리스트에 여러 웨이블존 일괄 추가 API 추가
  - 장소 리스트에서 웨이블존 제거 API 추가
  - 동일한 리스트명 중복 시 명확한 오류 응답 제공

- Chores
  - 인증 오류 코드 체계 일부 정비 (UNAUTHORIZED 코드 업데이트)
  - 사용자 영역 오류 케이스 확장(리스트명 중복 추가)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->