### PR TITLE
[fix] 페이징 관련 오프바이원 버그 수정 + 페이징 제약 및 검증 로직 개선 

### DIFF
--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -15,11 +15,13 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
+@Validated
 @RequestMapping("/api/v1/users/places")
 @RequiredArgsConstructor
 public class UserPlaceController {

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -38,11 +38,15 @@ public class UserPlaceController {
             @RequestBody @Valid UserPlaceCreateRequestDto request
     ) {
         Long placeId = userPlaceService.createPlaceList(userId, request);
+        String normalizedTitle = request.title().trim();
+        String normalizedColor = (request.color() == null || request.color().isBlank())
+                ? "GRAY"
+                : request.color().trim().toUpperCase();
         return CommonResponse.success(
                 UserPlaceCreateResponseDto.builder()
                         .placeId(placeId)
-                        .title(request.title())
-                        .color((request.color() == null || request.color().isBlank()) ? "GRAY" : request.color())
+                        .title(normalizedTitle)
+                        .color(normalizedColor)
                         .message("리스트가 생성되었습니다.")
                         .build()
         );

--- a/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
+++ b/src/main/java/com/wayble/server/user/controller/UserPlaceController.java
@@ -11,6 +11,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
@@ -96,7 +98,7 @@ public class UserPlaceController {
 
     @GetMapping("/zones")
     @Operation(summary = "특정 장소 내 웨이블존 목록 조회(페이징)",
-            description = "placeId로 해당 장소 내부의 웨이블존 카드 목록을 반환합니다. (page는 1부터 시작.)")
+            description = "placeId로 해당 장소 내부의 웨이블존 카드 목록을 반환합니다. (page는 0부터 시작.)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "유저/장소를 찾을 수 없음"),
@@ -105,8 +107,8 @@ public class UserPlaceController {
     public CommonResponse<Page<WaybleZoneListResponseDto>> getZonesInPlace(
             @Parameter(hidden = true) @CurrentUser Long userId,
             @RequestParam Long placeId,
-            @RequestParam(defaultValue = "1") Integer page,
-            @RequestParam(defaultValue = "20") Integer size
+            @RequestParam(defaultValue = "0") @Min(0) Integer page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) Integer size
     ) {
         Page<WaybleZoneListResponseDto> zones = userPlaceService.getZonesInPlace(userId, placeId, page, size);
         return CommonResponse.success(zones);

--- a/src/main/java/com/wayble/server/user/service/UserPlaceService.java
+++ b/src/main/java/com/wayble/server/user/service/UserPlaceService.java
@@ -112,9 +112,7 @@ public class UserPlaceService {
         UserPlace place = userPlaceRepository.findByIdAndUser_Id(placeId, userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.PLACE_NOT_FOUND));
 
-        int zeroBased = Math.max(0, page - 1);
-
-        Pageable pageable = PageRequest.of(zeroBased, size, Sort.by(Sort.Direction.DESC, "id"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
         Page<WaybleZone> zones = mappingRepository.findZonesByPlaceId(place.getId(), pageable);
 
         return zones.map(z ->

--- a/src/main/java/com/wayble/server/user/service/UserPlaceService.java
+++ b/src/main/java/com/wayble/server/user/service/UserPlaceService.java
@@ -41,17 +41,18 @@ public class UserPlaceService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
 
-        userPlaceRepository.findByUser_IdAndTitle(userId, request.title())
+        String normalizedTitle = request.title().trim();
+        userPlaceRepository.findByUser_IdAndTitle(userId, normalizedTitle)
                 .ifPresent(p -> { throw new ApplicationException(UserErrorCase.PLACE_TITLE_DUPLICATED); });
 
-        String color = (request.color() == null || request.color().isBlank()) ? "GRAY" : request.color();
+        String color = request.color() == null ? null : request.color().trim();
+        color = (color == null || color.isEmpty()) ? "GRAY" : color.toUpperCase();
 
         UserPlace saved = userPlaceRepository.save(
                 UserPlace.builder()
-                        .title(request.title())
+                        .title(normalizedTitle)
                         .color(color)
                         .user(user)
-                        .savedCount(0)
                         .build()
         );
         return saved.getId();


### PR DESCRIPTION
## ✔️ 연관 이슈

-  #170 

## 📝 작업 내용

> 페이징 관련 오프바이원 버그를 수정 + 코드리뷰 반영하여 페이징 검증 로직 개선 

### 스크린샷 (선택)
> X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - /zones 페이징 파라미터에 유효성 검증 추가: page는 0 이상, size는 1~100. 기본값 page=0, size=20.
- 버그 수정
  - 장소 목록 생성 시 제목의 앞뒤 공백을 제거하고 동일/유사(공백 차이) 제목 중복 저장 방지.
  - 색상 값 공백 제거·대문자 정규화 및 기본값 GRAY 자동 적용으로 표시 일관성 개선.
- 문서화
  - /zones 페이징이 0부터 시작(0-based)함을 명시하여 API 사용 방식 명확화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->